### PR TITLE
[ClangAstDumper] Modified CMakeLists and FindLLVM3.8.cmake for macOS

### DIFF
--- a/ClangAstDumper/CMakeLists.txt
+++ b/ClangAstDumper/CMakeLists.txt
@@ -9,15 +9,20 @@ include("../deps.cmake")
 # Add Modules
 deps_find_package(llvm3.8 REQUIRED) # LLVM
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3 -static-libgcc -static-libstdc++")
+if(SYSTEM_PLATFORM STREQUAL "MacOS")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++ -O3")
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3 -static-libgcc -static-libstdc++")
+endif()
+
 
 #Enable debug
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEBUG")
 
-# For Centos
+# For CentOS and macOS
 # Set SYSTEM_PLATFORM in deps_config.cmake
-if(SYSTEM_PLATFORM STREQUAL "Centos")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS")
+if(SYSTEM_PLATFORM STREQUAL "Centos" OR SYSTEM_PLATFORM STREQUAL "MacOS")
+  	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS")
 endif()
 
 
@@ -26,18 +31,16 @@ set(SOURCE_FILES
 		main.cpp
 		ClangAst.cpp
 		ClangAstDumper.cpp
-		#ClangAstDumper.h
 		ClangAstDumperTypes.cpp
 		ClangAstDumperStmts.cpp
 		ClangAstDumperDecls.cpp
 		ClangAstDumperDeclsInfo.cpp
 		ClangAstDumperExtra.cpp
 		TypeMarker.cpp
-		#TypeMarker.h
-		#ClangAstDumperConstants.h
-		#TEst.h
 		InfoDumper.cpp
-		InfoDumperDecls.cpp ChildrenVisitorDecls.cpp ClangNodes.cpp)
+		InfoDumperDecls.cpp 
+    ChildrenVisitorDecls.cpp 
+    ClangNodes.cpp)
 
 add_executable(ClangAstDumper ${SOURCE_FILES})
 
@@ -49,4 +52,4 @@ target_include_directories(ClangAstDumper
 # Add Libraries
 target_link_libraries(ClangAstDumper
         ${DEPS_LIBRARIES}
-        )
+)

--- a/deps/FindLLVM3.8.cmake
+++ b/deps/FindLLVM3.8.cmake
@@ -29,11 +29,20 @@ list(APPEND llvm3.8_INCLUDES
 # Ideally we would use 'find_libraries'
 LINK_DIRECTORIES("${LIB_DIR}/build/lib")
 
+set(LINKER_GROUP_START "-Wl,--start-group")
+set(LINKER_GROUP_END "-Wl,--end-group")
+
+if(APPLE)
+  # Apple Clang linker does not understand groups
+  unset(LINKER_GROUP_START)
+  unset(LINKER_GROUP_END)
+endif()
+
 #find_libraries(llvm3.8_LIBRARIES "${LIB_DIR}/build/lib" 
 list(APPEND llvm3.8_LIBRARIES 
 	
 	# Clang libraries, they have circular dependencies, so they are inside a group
-	-Wl,--start-group
+  ${LINKER_GROUP_START}
         clangAnalysis
         #clangApplyReplacements
         clangARCMigrate
@@ -71,7 +80,7 @@ list(APPEND llvm3.8_LIBRARIES
         #clangTidyUtils
         clangTooling
         clangToolingCore
-	-Wl,--end-group
+  ${LINKER_GROUP_END}
 		
 	# LLVM libraries, as given by 'llvm-config --libs'
 	LLVMLTO
@@ -131,21 +140,23 @@ list(APPEND llvm3.8_LIBRARIES
 	LLVMSupport
 )
 	
-	
-	
-	
 
-if(UNIX)
+if(UNIX AND NOT APPLE)
+  # Generic UNIX dependencies
 	list(APPEND llvm3.8_LIBRARIES 
 		rt
-		tinfo
+    tinfo
+    z
+		m
+		dl
+	)
+elseif(APPLE)
+  # macOS dependencies
+  list(APPEND llvm3.8_LIBRARIES 
 		z
 		m
 		dl
-	
-		# Needed by LLVMSupport
-		# CentOS does not support this, you can comment this
-		#c++abi
+    ncurses	
 	)
 endif()
-
+

--- a/deps_config.cmake
+++ b/deps_config.cmake
@@ -4,5 +4,5 @@
 cmake_minimum_required(VERSION 3.2)
 
 #set(HOST_SPECS_TOOLS "specs-tools")
-#set(SYSTEM_PLATFORM "Centos")
-#set(DEPS_COMPILER "gcc5")
+set(SYSTEM_PLATFORM "MacOS")
+set(DEPS_COMPILER "gcc5")


### PR DESCRIPTION
Change compiler flags and options for AppleClang 
 - remove -static-libgcc
 - add -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS
 - do not use -Wl, --start-group, because AppleClang does not understand these
 - remove rt and tinfo libs, use ncurses instead

