### PR TITLE
Add an optional condition to timer insertions

### DIFF
--- a/ClavaLaraApi/src-lara/clava/lara/code/Timer.lara
+++ b/ClavaLaraApi/src-lara/clava/lara/code/Timer.lara
@@ -19,7 +19,7 @@ Timer.prototype.addedDefines = new StringSet();
  * @param $end Ending point of the time measure. If undefined, measure is done around starting point.
  * @param {String|$expr} $condition - If defined, adds an if statement wrapping the time measuring code. If a string, it is converted to a literal expression.
  */
-Timer.prototype.time = function($start, prefix, $end, $condition) {
+Timer.prototype.time = function ($start, prefix, $end, $condition) {
 
     if (!this._timeValidate($start, $end, 'function')) {
         return;
@@ -27,10 +27,10 @@ Timer.prototype.time = function($start, prefix, $end, $condition) {
 
     var $file = $start.ancestor('file');
 
-    if($file === undefined) {
-		println("Could not find the corresponding file of the given joinpoint: " + $jp);
-		return;
-	}else if ($file.isCxx) {
+    if ($file === undefined) {
+        println("Could not find the corresponding file of the given joinpoint: " + $jp);
+        return;
+    } else if ($file.isCxx) {
         return this._time_cpp($start, prefix, $end, $condition);
     } else {
         return this._time_c($start, prefix, $end, $condition);
@@ -38,8 +38,8 @@ Timer.prototype.time = function($start, prefix, $end, $condition) {
 }
 
 
-Timer.prototype._time_cpp = function($start, prefix, $end, $condition) {
-    if (this.timeUnits.unit == this.timeUnits._timerUnit.DAYS){
+Timer.prototype._time_cpp = function ($start, prefix, $end, $condition) {
+    if (this.timeUnits.unit == this.timeUnits._timerUnit.DAYS) {
         throw "Timer Exception: Timer metrics not implemented for DAYS in C++";
     }
     var logger = new Logger(false, this.filename);
@@ -65,23 +65,22 @@ Timer.prototype._time_cpp = function($start, prefix, $end, $condition) {
 
     var $codeTic = ClavaJoinPoints.stmtLiteral(_timer_cpp_now(startVar));
     var $codeToc = ClavaJoinPoints.stmtLiteral(_timer_cpp_now(endVar));
-	var $insertionTic = $codeTic;
-	var $insertionToc = $codeToc;
+    var $insertionTic = $codeTic;
+    var $insertionToc = $codeToc;
 
 
-	if ($condition !== undefined) {
-		$insertionTic = ClavaJoinPoints.ifStmt($condition, $codeTic);
-		$insertionToc = ClavaJoinPoints.ifStmt($condition, $codeToc);
-	}
+    if ($condition !== undefined) {
+        $insertionTic = ClavaJoinPoints.ifStmt($condition, $codeTic);
+        $insertionToc = ClavaJoinPoints.ifStmt($condition, $codeToc);
+    }
 
-	var cppUnit = this.timeUnits.getCppTimeUnit();
-
-    // Create literal node with calculation of time interval
-    $timingResult = ClavaJoinPoints.exprLiteral(_timer_cpp_calc_interval(startVar, endVar, cppUnit));
+    var cppUnit = this.timeUnits.getCppTimeUnit();
 
     // Declare variable for time interval, which uses calculation as initialization
     var timeIntervalVar = IdGenerator.next("clava_timing_duration_");
-    $timingResultDecl = ClavaJoinPoints.varDecl(timeIntervalVar, $timingResult);
+    // Create literal node with calculation of time interval
+    $timingResult = ClavaJoinPoints.exprLiteral(_timer_cpp_calc_interval(startVar, endVar, cppUnit, timeIntervalVar));
+
 
     // Build message
     logger.append(prefix).appendDouble(timeIntervalVar);
@@ -90,37 +89,50 @@ Timer.prototype._time_cpp = function($start, prefix, $end, $condition) {
     }
     logger.ln();
 
-	// Check if $start is a scope
-	if($start.instanceOf("scope")) {
-		// Insert code
-		$start.insertBegin($insertionTic);
-	} else {
-		// Insert code
-		$start.insertBefore($insertionTic);
-	}
-	
-	var afterJp = undefined;
-	
-	// Check if $end is a scope
-	if($end.instanceOf("scope")) {
-		$end.insertEnd($insertionToc);
-	} else {
-		$end.insertAfter($insertionToc);
-	}
-	afterJp = $codeToc.insertAfter($timingResultDecl);
+    // Check if $start is a scope
+    if ($start.instanceOf("scope")) {
+        $start.insertBegin($insertionTic);
+    } else {
+        $start.insertBefore($insertionTic);
+    }
+
+    $startVarDecl = ClavaJoinPoints.stmtLiteral(_timer_cpp_define_time_var(startVar));
+    $endVarDecl = ClavaJoinPoints.stmtLiteral(_timer_cpp_define_time_var(endVar));
+    $timingResultDecl = ClavaJoinPoints.stmtLiteral(_timer_cpp_define_differential_var(cppUnit, timeIntervalVar));
+    $insertionTic.insertBefore($startVarDecl);
+    $insertionTic.insertBefore($endVarDecl);
+    $insertionTic.insertBefore($timingResultDecl);
+
+    
+
+    var afterJp = undefined;
+
+    // Check if $end is a scope
+    if ($end.instanceOf("scope")) {
+        $end.insertEnd($insertionToc);
+    } else {
+        $end.insertAfter($insertionToc);
+    }
+    $codeToc.insertAfter($timingResult);
+    
+    if ($condition !== undefined) {
+        afterJp = $insertionToc;
+    } else {
+        afterJp = $timingResult;
+    }
 
     // Log time information
-	if(this.print) {
-		logger.log($timingResultDecl);
-		afterJp = logger.getAfterJp();
-	}
-	
-	this._setAfterJp(afterJp);
-	
-	return timeIntervalVar;
+    if (this.print) {
+        logger.log(afterJp);
+        afterJp = logger.getAfterJp();
+    }
+
+    this._setAfterJp(afterJp);
+
+    return timeIntervalVar;
 }
 
-Timer.prototype._time_c = function($start, prefix, $end, $condition) {
+Timer.prototype._time_c = function ($start, prefix, $end, $condition) {
 
     var logger = new Logger(false, this.filename);
 
@@ -135,7 +147,7 @@ Timer.prototype._time_c = function($start, prefix, $end, $condition) {
 
     $file = $start.ancestor("file");
 
-    
+
     var $varDecl, $codeBefore, $codeAfter, timeIntervalVar;
 
     // Declare variable for time interval, which uses calculation as initialization
@@ -152,10 +164,10 @@ Timer.prototype._time_c = function($start, prefix, $end, $condition) {
         var endVar = IdGenerator.next("clava_timing_end_");
         var frequencyVar = IdGenerator.next("clava_timing_frequency_");
 
-		$varDecl = ClavaJoinPoints.stmtLiteral(_timer_c_windows_declare_vars(startVar, endVar, frequencyVar));
+        $varDecl = ClavaJoinPoints.stmtLiteral(_timer_c_windows_declare_vars(startVar, endVar, frequencyVar));
         $codeBefore = ClavaJoinPoints.stmtLiteral(_timer_c_windows_get_time(startVar));
         $codeAfter = ClavaJoinPoints.stmtLiteral(_timer_c_windows_get_time(endVar));
-        
+
 
         // Create literal node with calculation of time interval
         $timingResult = ClavaJoinPoints.exprLiteral(_timer_c_windows_calc_interval(startVar, endVar, frequencyVar, this.timeUnits.getMagnitudeFactorFromSeconds()), ClavaJoinPoints.builtinType("double"));
@@ -165,15 +177,15 @@ Timer.prototype._time_c = function($start, prefix, $end, $condition) {
     } else if (Platforms.isLinux()) {
         // Add includes
         $file.exec addInclude("time.h", true);
-		
-		// If C99 or C11 standard, needs define at the beginning of the file
-		// https://stackoverflow.com/questions/42597685/storage-size-of-timespec-isnt-known
-		var needsDefine = Clava.getStandard() === "c99" || Clava.getStandard() === "c11";
-		if(needsDefine && !this.addedDefines.has($file.location)) {
-			$file.exec insertBegin("#define _POSIX_C_SOURCE 199309L");
-			this.addedDefines.add($file.location);
-		}		
-	
+
+        // If C99 or C11 standard, needs define at the beginning of the file
+        // https://stackoverflow.com/questions/42597685/storage-size-of-timespec-isnt-known
+        var needsDefine = Clava.getStandard() === "c99" || Clava.getStandard() === "c11";
+        if (needsDefine && !this.addedDefines.has($file.location)) {
+            $file.exec insertBegin("#define _POSIX_C_SOURCE 199309L");
+            this.addedDefines.add($file.location);
+        }
+
 
         // get variable names
         var startVar = IdGenerator.next("clava_timing_start_");
@@ -187,7 +199,7 @@ Timer.prototype._time_c = function($start, prefix, $end, $condition) {
         $timingResult = ClavaJoinPoints.exprLiteral(_timer_c_linux_calc_interval(startVar, endVar, this.timeUnits.getMagnitudeFactorFromSeconds()), ClavaJoinPoints.builtinType("double"));
 
         $timingResultDecl = ClavaJoinPoints.varDecl(timeIntervalVar, $timingResult);
-    }else{
+    } else {
         throw "Timer Exception: Platform not supported (Windows and Linux only)";
     }
 
@@ -198,45 +210,45 @@ Timer.prototype._time_c = function($start, prefix, $end, $condition) {
     }
     logger.ln();
 
-	var $insertionTic = $codeBefore;
-	var $insertionToc = $codeAfter;
+    var $insertionTic = $codeBefore;
+    var $insertionToc = $codeAfter;
 
-	if ($condition !== undefined) {
-		$insertionTic = ClavaJoinPoints.ifStmt($condition, $codeBefore);
-		$insertionToc = ClavaJoinPoints.ifStmt($condition, $codeAfter);
-	}
+    if ($condition !== undefined) {
+        $insertionTic = ClavaJoinPoints.ifStmt($condition, $codeBefore);
+        $insertionToc = ClavaJoinPoints.ifStmt($condition, $codeAfter);
+    }
 
-	// Check if $start is a scope
-	if($start.instanceOf("scope")) {
-		// Insert code
-		$start.insertBegin($insertionTic);
-	} else {
-		// Insert code
-		$start.insertBefore($insertionTic);
-	}
-	$insertionTic.insertBefore($varDecl);
-	
-	
-	var afterJp = undefined;
-	
-	// Check if $end is a scope
-	if($end.instanceOf("scope")) {
-		$end.insertEnd($insertionToc);
-	} else {
-		$end.insertAfter($insertionToc);
-	}
-	afterJp = $codeAfter.insertAfter($timingResultDecl);
+    // Check if $start is a scope
+    if ($start.instanceOf("scope")) {
+        // Insert code
+        $start.insertBegin($insertionTic);
+    } else {
+        // Insert code
+        $start.insertBefore($insertionTic);
+    }
+    $insertionTic.insertBefore($varDecl);
+
+
+    var afterJp = undefined;
+
+    // Check if $end is a scope
+    if ($end.instanceOf("scope")) {
+        $end.insertEnd($insertionToc);
+    } else {
+        $end.insertAfter($insertionToc);
+    }
+    afterJp = $codeAfter.insertAfter($timingResultDecl);
 
 
     // Log time information
-	if(this.print) {
-		logger.log($timingResultDecl);
-		afterJp = logger.getAfterJp();
-	}
-	
-	this._setAfterJp(afterJp);
-	
-	return timeIntervalVar;
+    if (this.print) {
+        logger.log($timingResultDecl);
+        afterJp = logger.getAfterJp();
+    }
+
+    this._setAfterJp(afterJp);
+
+    return timeIntervalVar;
 
 }
 
@@ -252,7 +264,7 @@ QueryPerformanceCounter(&[[timeVar]]);
 }%end
 
 codedef _timer_c_windows_calc_interval(timeStartVar, timeEndVar, timeFrequencyVar, factorConversion)%{
-(([[timeEndVar]].QuadPart-[[timeStartVar]].QuadPart) / (double)[[timeFrequencyVar]].QuadPart) * ([[factorConversion]])
+(([[timeEndVar]].QuadPart - [[timeStartVar]].QuadPart) / (double)[[timeFrequencyVar]].QuadPart) * ([[factorConversion]])
 }%end
 
 //Linux
@@ -266,14 +278,22 @@ clock_gettime(CLOCK_MONOTONIC, &[[timeVar]]);
 
 
 codedef _timer_c_linux_calc_interval(timeStartVar, timeEndVar, factorConversion)%{
-(([[timeEndVar]].tv_sec + ((double) [[timeEndVar]].tv_nsec / 1000000000)) - ([[timeStartVar]].tv_sec + ((double) [[timeStartVar]].tv_nsec / 1000000000))) * ([[factorConversion]])
+(([[timeEndVar]].tv_sec + ((double)[[timeEndVar]].tv_nsec / 1000000000)) - ([[timeStartVar]].tv_sec + ((double)[[timeStartVar]].tv_nsec / 1000000000))) * ([[factorConversion]])
 }%end
 
 //Cpp codedefs
-codedef _timer_cpp_now(timeVar)%{
-std::chrono::high_resolution_clock::time_point [[timeVar]] = std::chrono::high_resolution_clock::now();
+codedef _timer_cpp_define_time_var(timeVar)%{
+std::chrono::high_resolution_clock::time_point [[timeVar]];
 }%end
 
-codedef _timer_cpp_calc_interval(startVar, endVar, unit)%{
-std::chrono::duration_cast<std::chrono::[[unit]]>([[endVar]] - [[startVar]]).count()
+codedef _timer_cpp_define_differential_var(unit, varName)%{
+std::chrono::[[unit]] [[varName]];
+}%end
+
+codedef _timer_cpp_now(timeVar)%{
+[[timeVar]] = std::chrono::high_resolution_clock::now();
+}%end
+
+codedef _timer_cpp_calc_interval(startVar, endVar, unit, differentialVar)%{
+[[differentialVar]] = std::chrono::duration_cast<std::chrono::[[unit]]> ([[endVar]] - [[startVar]]).count()
 }%end

--- a/ClavaLaraApi/src-lara/clava/lara/code/Timer.lara
+++ b/ClavaLaraApi/src-lara/clava/lara/code/Timer.lara
@@ -140,19 +140,19 @@ Timer.prototype._time_c = function ($start, prefix, $end, $condition) {
     if (prefix === undefined) {
         prefix = "";
     }
-
+    
     if ($end === undefined) {
         $end = $start;
     }
-
+    
     $file = $start.ancestor("file");
-
-
-    var $varDecl, $codeBefore, $codeAfter, timeIntervalVar;
-
+    
+    
+    var $varDecl, $codeBefore, $codeAfter, $timingResult;
+    
     // Declare variable for time interval, which uses calculation as initialization
     var timeIntervalVar = IdGenerator.next("clava_timing_duration_");
-    var $timingResultDecl;
+    var $timingResultDecl = ClavaJoinPoints.varDeclNoInit(timeIntervalVar, ClavaJoinPoints.builtinType("double"));
 
     if (Platforms.isWindows()) { //use QueryPerformanceCounter
         // Add includes
@@ -170,9 +170,7 @@ Timer.prototype._time_c = function ($start, prefix, $end, $condition) {
 
 
         // Create literal node with calculation of time interval
-        $timingResult = ClavaJoinPoints.exprLiteral(_timer_c_windows_calc_interval(startVar, endVar, frequencyVar, this.timeUnits.getMagnitudeFactorFromSeconds()), ClavaJoinPoints.builtinType("double"));
-
-        $timingResultDecl = ClavaJoinPoints.varDecl(timeIntervalVar, $timingResult);
+        $timingResult = ClavaJoinPoints.exprLiteral(_timer_c_windows_calc_interval(startVar, endVar, timeIntervalVar, frequencyVar, this.timeUnits.getMagnitudeFactorFromSeconds()), $timingResultDecl.type);
 
     } else if (Platforms.isLinux()) {
         // Add includes
@@ -196,28 +194,27 @@ Timer.prototype._time_c = function ($start, prefix, $end, $condition) {
         $codeAfter = ClavaJoinPoints.stmtLiteral(_timer_c_linux_get_time(endVar));
 
         // Create literal node with calculation of time interval
-        $timingResult = ClavaJoinPoints.exprLiteral(_timer_c_linux_calc_interval(startVar, endVar, this.timeUnits.getMagnitudeFactorFromSeconds()), ClavaJoinPoints.builtinType("double"));
+        $timingResult = ClavaJoinPoints.exprLiteral(_timer_c_linux_calc_interval(startVar, endVar, timeIntervalVar, this.timeUnits.getMagnitudeFactorFromSeconds()), $timingResultDecl.type);
 
-        $timingResultDecl = ClavaJoinPoints.varDecl(timeIntervalVar, $timingResult);
     } else {
         throw "Timer Exception: Platform not supported (Windows and Linux only)";
     }
-
+    
     // Build message
     logger.append(prefix).appendDouble(timeIntervalVar);
     if (this.printUnit) {
         logger.append(this.timeUnits.getUnitsString());
     }
     logger.ln();
-
+    
     var $insertionTic = $codeBefore;
     var $insertionToc = $codeAfter;
-
+    
     if ($condition !== undefined) {
         $insertionTic = ClavaJoinPoints.ifStmt($condition, $codeBefore);
         $insertionToc = ClavaJoinPoints.ifStmt($condition, $codeAfter);
     }
-
+    
     // Check if $start is a scope
     if ($start.instanceOf("scope")) {
         // Insert code
@@ -227,6 +224,7 @@ Timer.prototype._time_c = function ($start, prefix, $end, $condition) {
         $start.insertBefore($insertionTic);
     }
     $insertionTic.insertBefore($varDecl);
+    $insertionTic.insertBefore($timingResultDecl);
 
 
     var afterJp = undefined;
@@ -237,12 +235,17 @@ Timer.prototype._time_c = function ($start, prefix, $end, $condition) {
     } else {
         $end.insertAfter($insertionToc);
     }
-    afterJp = $codeAfter.insertAfter($timingResultDecl);
+    afterJp = $codeAfter.insertAfter($timingResult);
 
+    if ($condition !== undefined) {
+        afterJp = $insertionToc;
+    } else {
+        afterJp = $timingResult;
+    }
 
     // Log time information
     if (this.print) {
-        logger.log($timingResultDecl);
+        logger.log(afterJp);
         afterJp = logger.getAfterJp();
     }
 
@@ -263,8 +266,8 @@ codedef _timer_c_windows_get_time(timeVar)%{
 QueryPerformanceCounter(&[[timeVar]]);
 }%end
 
-codedef _timer_c_windows_calc_interval(timeStartVar, timeEndVar, timeFrequencyVar, factorConversion)%{
-(([[timeEndVar]].QuadPart - [[timeStartVar]].QuadPart) / (double)[[timeFrequencyVar]].QuadPart) * ([[factorConversion]])
+codedef _timer_c_windows_calc_interval(timeStartVar, timeEndVar, timeDiffenceVar, timeFrequencyVar, factorConversion)%{
+[[timeDiffenceVar]] = (([[timeEndVar]].QuadPart - [[timeStartVar]].QuadPart) / (double)[[timeFrequencyVar]].QuadPart) * ([[factorConversion]])
 }%end
 
 //Linux
@@ -277,8 +280,8 @@ clock_gettime(CLOCK_MONOTONIC, &[[timeVar]]);
 }%end
 
 
-codedef _timer_c_linux_calc_interval(timeStartVar, timeEndVar, factorConversion)%{
-(([[timeEndVar]].tv_sec + ((double)[[timeEndVar]].tv_nsec / 1000000000)) - ([[timeStartVar]].tv_sec + ((double)[[timeStartVar]].tv_nsec / 1000000000))) * ([[factorConversion]])
+codedef _timer_c_linux_calc_interval(timeStartVar, timeEndVar, timeDiffenceVar, factorConversion)%{
+[[timeDiffenceVar]] = (([[timeEndVar]].tv_sec + ((double)[[timeEndVar]].tv_nsec / 1000000000)) - ([[timeStartVar]].tv_sec + ((double)[[timeStartVar]].tv_nsec / 1000000000))) * ([[factorConversion]])
 }%end
 
 //Cpp codedefs

--- a/ClavaLaraApi/src-lara/clava/lara/code/Timer.lara
+++ b/ClavaLaraApi/src-lara/clava/lara/code/Timer.lara
@@ -17,7 +17,7 @@ Timer.prototype.addedDefines = new StringSet();
  * @param $start [Mandatory] Starting point of the time measure
  * @param prefix Message that will appear before the time measure. If undefined, empty string will be used.
  * @param $end Ending point of the time measure. If undefined, measure is done around starting point.
- * @param {String|$expr} $condition - The condition of the if statement. If a string, it is converted to a literal expression.
+ * @param {String|$expr} $condition - If defined, adds an if statement wrapping the time measuring code. If a string, it is converted to a literal expression.
  */
 Timer.prototype.time = function($start, prefix, $end, $condition) {
 
@@ -35,9 +35,6 @@ Timer.prototype.time = function($start, prefix, $end, $condition) {
     } else {
         return this._time_c($start, prefix, $end, $condition);
     }
-
-    //return this;
-    //PrintOnce.message("Timer.time: not implemented yet for C");
 }
 
 

--- a/ClavaLaraApi/src-lara/clava/lara/code/Timer.lara
+++ b/ClavaLaraApi/src-lara/clava/lara/code/Timer.lara
@@ -98,7 +98,10 @@ Timer.prototype._time_cpp = function ($start, prefix, $end, $condition) {
 
     $startVarDecl = ClavaJoinPoints.stmtLiteral(_timer_cpp_define_time_var(startVar));
     $endVarDecl = ClavaJoinPoints.stmtLiteral(_timer_cpp_define_time_var(endVar));
-    $timingResultDecl = ClavaJoinPoints.stmtLiteral(_timer_cpp_define_differential_var(cppUnit, timeIntervalVar));
+    $timingResultDecl = ClavaJoinPoints.varDeclNoInit(
+	    timeIntervalVar,
+	    ClavaJoinPoints.typeLiteral("std::chrono::"+cppUnit)
+	);
     $insertionTic.insertBefore($startVarDecl);
     $insertionTic.insertBefore($endVarDecl);
     $insertionTic.insertBefore($timingResultDecl);

--- a/ClavaLaraApi/src-lara/clava/lara/code/Timer.lara
+++ b/ClavaLaraApi/src-lara/clava/lara/code/Timer.lara
@@ -83,7 +83,7 @@ Timer.prototype._time_cpp = function ($start, prefix, $end, $condition) {
 
 
     // Build message
-    logger.append(prefix).appendDouble(timeIntervalVar);
+    logger.append(prefix).appendLong(_timer_cpp_print_interval(cppUnit, timeIntervalVar));
     if (this.printUnit) {
         logger.append(this.timeUnits.getUnitsString());
     }
@@ -100,7 +100,7 @@ Timer.prototype._time_cpp = function ($start, prefix, $end, $condition) {
     $endVarDecl = ClavaJoinPoints.stmtLiteral(_timer_cpp_define_time_var(endVar));
     $timingResultDecl = ClavaJoinPoints.varDeclNoInit(
 	    timeIntervalVar,
-	    ClavaJoinPoints.typeLiteral("std::chrono::"+cppUnit)
+	    ClavaJoinPoints.typeLiteral("std::chrono::high_resolution_clock::duration")
 	);
     $insertionTic.insertBefore($startVarDecl);
     $insertionTic.insertBefore($endVarDecl);
@@ -126,8 +126,10 @@ Timer.prototype._time_cpp = function ($start, prefix, $end, $condition) {
 
     // Log time information
     if (this.print) {
-        logger.log(afterJp);
-        afterJp = logger.getAfterJp();
+        logger.log($timingResult);
+        if ($condition === undefined) {
+            afterJp = logger.getAfterJp();
+        }
     }
 
     this._setAfterJp(afterJp);
@@ -292,14 +294,14 @@ codedef _timer_cpp_define_time_var(timeVar)%{
 std::chrono::high_resolution_clock::time_point [[timeVar]];
 }%end
 
-codedef _timer_cpp_define_differential_var(unit, varName)%{
-std::chrono::[[unit]] [[varName]];
-}%end
-
 codedef _timer_cpp_now(timeVar)%{
 [[timeVar]] = std::chrono::high_resolution_clock::now();
 }%end
 
 codedef _timer_cpp_calc_interval(startVar, endVar, unit, differentialVar)%{
-[[differentialVar]] = std::chrono::duration_cast<std::chrono::[[unit]]> ([[endVar]] - [[startVar]]).count()
+[[differentialVar]] = [[endVar]] - [[startVar]]
+}%end
+
+codedef _timer_cpp_print_interval(unit, differentialVar)%{
+std::chrono::duration_cast<std::chrono::[[unit]]> ([[differentialVar]]).count()
 }%end

--- a/ClavaLaraApi/src-lara/clava/lara/code/Timer.lara
+++ b/ClavaLaraApi/src-lara/clava/lara/code/Timer.lara
@@ -17,8 +17,9 @@ Timer.prototype.addedDefines = new StringSet();
  * @param $start [Mandatory] Starting point of the time measure
  * @param prefix Message that will appear before the time measure. If undefined, empty string will be used.
  * @param $end Ending point of the time measure. If undefined, measure is done around starting point.
+ * @param {String|$expr} $condition - The condition of the if statement. If a string, it is converted to a literal expression.
  */
-Timer.prototype.time = function($start, prefix, $end) {
+Timer.prototype.time = function($start, prefix, $end, $condition) {
 
     if (!this._timeValidate($start, $end, 'function')) {
         return;
@@ -30,9 +31,9 @@ Timer.prototype.time = function($start, prefix, $end) {
 		println("Could not find the corresponding file of the given joinpoint: " + $jp);
 		return;
 	}else if ($file.isCxx) {
-        return this._time_cpp($start, prefix, $end);
+        return this._time_cpp($start, prefix, $end, $condition);
     } else {
-        return this._time_c($start, prefix, $end);
+        return this._time_c($start, prefix, $end, $condition);
     }
 
     //return this;
@@ -40,7 +41,7 @@ Timer.prototype.time = function($start, prefix, $end) {
 }
 
 
-Timer.prototype._time_cpp = function($start, prefix, $end) {
+Timer.prototype._time_cpp = function($start, prefix, $end, $condition) {
     if (this.timeUnits.unit == this.timeUnits._timerUnit.DAYS){
         throw "Timer Exception: Timer metrics not implemented for DAYS in C++";
     }
@@ -65,10 +66,18 @@ Timer.prototype._time_cpp = function($start, prefix, $end) {
     var startVar = IdGenerator.next("clava_timing_start_");
     var endVar = IdGenerator.next("clava_timing_end_");
 
-    var codeTic = _timer_cpp_now(startVar);
-    var codeToc = _timer_cpp_now(endVar);
+    var $codeTic = ClavaJoinPoints.stmtLiteral(_timer_cpp_now(startVar));
+    var $codeToc = ClavaJoinPoints.stmtLiteral(_timer_cpp_now(endVar));
+	var $insertionTic = $codeTic;
+	var $insertionToc = $codeToc;
 
-    var cppUnit = this.timeUnits.getCppTimeUnit();
+
+	if ($condition !== undefined) {
+		$insertionTic = ClavaJoinPoints.ifStmt($condition, $codeTic);
+		$insertionToc = ClavaJoinPoints.ifStmt($condition, $codeToc);
+	}
+
+	var cppUnit = this.timeUnits.getCppTimeUnit();
 
     // Create literal node with calculation of time interval
     $timingResult = ClavaJoinPoints.exprLiteral(_timer_cpp_calc_interval(startVar, endVar, cppUnit));
@@ -84,51 +93,24 @@ Timer.prototype._time_cpp = function($start, prefix, $end) {
     }
     logger.ln();
 
-	
 	// Check if $start is a scope
 	if($start.instanceOf("scope")) {
 		// Insert code
-		$start.insertBegin(codeTic);
+		$start.insertBegin($insertionTic);
 	} else {
 		// Insert code
-		$start.insertBefore(codeTic);
+		$start.insertBefore($insertionTic);
 	}
 	
 	var afterJp = undefined;
 	
 	// Check if $end is a scope
 	if($end.instanceOf("scope")) {
-		// 'insertEnd' insertions must be done in sequential order		
-		$end.insertEnd(codeToc);
-		afterJp = $end.insertEnd($timingResultDecl);
+		$end.insertEnd($insertionToc);
 	} else {
-		// 'insertAfter' insertions must be done in reverse order		
-		afterJp = $end.insertAfter($timingResultDecl);
-		$end.insertAfter(codeToc);
+		$end.insertAfter($insertionToc);
 	}
-	/*
-	// If $start/$end parent do not have a statement ancestor, use insertBegin/End instead
-	if($start.ancestor("statement") === undefined || $end.ancestor("statement") === undefined) {
-
-		// Insert code
-		$start.insertBegin(codeTic);
-
-		// 'end' insertions must be done in sequential order		
-		$end.insertEnd(codeToc);
-		$end.insertEnd($timingResultDecl);
-
-
-	} else {
-		// Insert code
-		$start.insertBefore(codeTic);
-
-		// 'after' insertions must be done in reverse order		
-		$end.insertAfter($timingResultDecl);
-		$end.insertAfter(codeToc);
-	}
-	*/
-
-
+	afterJp = $codeToc.insertAfter($timingResultDecl);
 
     // Log time information
 	if(this.print) {
@@ -141,7 +123,7 @@ Timer.prototype._time_cpp = function($start, prefix, $end) {
 	return timeIntervalVar;
 }
 
-Timer.prototype._time_c = function($start, prefix, $end) {
+Timer.prototype._time_c = function($start, prefix, $end, $condition) {
 
     var logger = new Logger(false, this.filename);
 
@@ -157,7 +139,7 @@ Timer.prototype._time_c = function($start, prefix, $end) {
     $file = $start.ancestor("file");
 
     
-    var codeBefore, codeAfter, timeIntervalVar;
+    var $varDecl, $codeBefore, $codeAfter, timeIntervalVar;
 
     // Declare variable for time interval, which uses calculation as initialization
     var timeIntervalVar = IdGenerator.next("clava_timing_duration_");
@@ -173,8 +155,10 @@ Timer.prototype._time_c = function($start, prefix, $end) {
         var endVar = IdGenerator.next("clava_timing_end_");
         var frequencyVar = IdGenerator.next("clava_timing_frequency_");
 
-        codeBefore = _timer_c_windows_declare_vars_now(startVar, endVar, frequencyVar);
-        codeAfter = _timer_c_windows_get_final_time(endVar);
+		$varDecl = ClavaJoinPoints.stmtLiteral(_timer_c_windows_declare_vars(startVar, endVar, frequencyVar));
+        $codeBefore = ClavaJoinPoints.stmtLiteral(_timer_c_windows_get_time(startVar));
+        $codeAfter = ClavaJoinPoints.stmtLiteral(_timer_c_windows_get_time(endVar));
+        
 
         // Create literal node with calculation of time interval
         $timingResult = ClavaJoinPoints.exprLiteral(_timer_c_windows_calc_interval(startVar, endVar, frequencyVar, this.timeUnits.getMagnitudeFactorFromSeconds()), ClavaJoinPoints.builtinType("double"));
@@ -198,8 +182,9 @@ Timer.prototype._time_c = function($start, prefix, $end) {
         var startVar = IdGenerator.next("clava_timing_start_");
         var endVar = IdGenerator.next("clava_timing_end_");
 
-        codeBefore = _timer_c_linux_declare_vars_now(startVar, endVar);
-        codeAfter = _timer_c_linux_get_final_time(endVar);
+        $varDecl = ClavaJoinPoints.stmtLiteral(_timer_c_linux_declare_vars(startVar, endVar));
+        $codeBefore = ClavaJoinPoints.stmtLiteral(_timer_c_linux_get_time(startVar));
+        $codeAfter = ClavaJoinPoints.stmtLiteral(_timer_c_linux_get_time(endVar));
 
         // Create literal node with calculation of time interval
         $timingResult = ClavaJoinPoints.exprLiteral(_timer_c_linux_calc_interval(startVar, endVar, this.timeUnits.getMagnitudeFactorFromSeconds()), ClavaJoinPoints.builtinType("double"));
@@ -216,48 +201,34 @@ Timer.prototype._time_c = function($start, prefix, $end) {
     }
     logger.ln();
 
+	var $insertionTic = $codeBefore;
+	var $insertionToc = $codeAfter;
+
+	if ($condition !== undefined) {
+		$insertionTic = ClavaJoinPoints.ifStmt($condition, $codeBefore);
+		$insertionToc = ClavaJoinPoints.ifStmt($condition, $codeAfter);
+	}
+
 	// Check if $start is a scope
 	if($start.instanceOf("scope")) {
 		// Insert code
-		$start.insertBegin(codeBefore);
+		$start.insertBegin($insertionTic);
 	} else {
 		// Insert code
-		$start.insertBefore(codeBefore);
+		$start.insertBefore($insertionTic);
 	}
+	$insertionTic.insertBefore($varDecl);
 	
 	
 	var afterJp = undefined;
 	
 	// Check if $end is a scope
 	if($end.instanceOf("scope")) {
-		// 'insertEnd' insertions must be done in sequential order		
-		$end.insertEnd(codeAfter);
-		afterJp = $end.insertEnd($timingResultDecl);
+		$end.insertEnd($insertionToc);
 	} else {
-		// 'insertAfter' insertions must be done in reverse order		
-		afterJp = $end.insertAfter($timingResultDecl);
-		$end.insertAfter(codeAfter);
+		$end.insertAfter($insertionToc);
 	}
-/*	
-	// If $start/$end parent do not have a statement ancestor, use insertBegin/End instead
-	if($start.ancestor("statement") === undefined || $end.ancestor("statement") === undefined) {
-
-		// Insert code
-		$start.insertBegin(codeBefore);
-
-		// 'end' insertions must be done in sequential order		
-		$end.insertEnd(codeAfter);
-		$end.insertEnd($timingResultDecl);
-		
-	} else {
-	    // Insert code
-		$start.insertBefore(codeBefore);
-
-		// 'after' insertions must be done in reverse order		
-		$end.insertAfter($timingResultDecl);
-		$end.insertAfter(codeAfter);
-	}
-*/
+	afterJp = $codeAfter.insertAfter($timingResultDecl);
 
 
     // Log time information
@@ -274,14 +245,13 @@ Timer.prototype._time_c = function($start, prefix, $end) {
 
 //C codedefs 
 // Windows
-codedef _timer_c_windows_declare_vars_now(timeStartVar, timeEndVar, timeFrequencyVar)%{
+codedef _timer_c_windows_declare_vars(timeStartVar, timeEndVar, timeFrequencyVar)%{
 LARGE_INTEGER [[timeStartVar]], [[timeEndVar]], [[timeFrequencyVar]];
 QueryPerformanceFrequency(&[[timeFrequencyVar]]);
-QueryPerformanceCounter(&[[timeStartVar]]);
 }%end
 
-codedef _timer_c_windows_get_final_time(timeEndVar)%{
-QueryPerformanceCounter(&[[timeEndVar]]);
+codedef _timer_c_windows_get_time(timeVar)%{
+QueryPerformanceCounter(&[[timeVar]]);
 }%end
 
 codedef _timer_c_windows_calc_interval(timeStartVar, timeEndVar, timeFrequencyVar, factorConversion)%{
@@ -289,14 +259,14 @@ codedef _timer_c_windows_calc_interval(timeStartVar, timeEndVar, timeFrequencyVa
 }%end
 
 //Linux
-codedef _timer_c_linux_declare_vars_now(timeStartVar, timeEndVar)%{
+codedef _timer_c_linux_declare_vars(timeStartVar, timeEndVar)%{
 struct timespec [[timeStartVar]], [[timeEndVar]];
-clock_gettime(CLOCK_MONOTONIC, &[[timeStartVar]]);
 }%end
 
-codedef _timer_c_linux_get_final_time(timeEndVar)%{
-clock_gettime(CLOCK_MONOTONIC, &[[timeEndVar]]);
+codedef _timer_c_linux_get_time(timeVar)%{
+clock_gettime(CLOCK_MONOTONIC, &[[timeVar]]);
 }%end
+
 
 codedef _timer_c_linux_calc_interval(timeStartVar, timeEndVar, factorConversion)%{
 (([[timeEndVar]].tv_sec + ((double) [[timeEndVar]].tv_nsec / 1000000000)) - ([[timeStartVar]].tv_sec + ((double) [[timeStartVar]].tv_nsec / 1000000000))) * ([[factorConversion]])


### PR DESCRIPTION
This condition makes it possible for the inserted timer code to be used only under specified times.

C and C++ insertions tested in Linux with `end` as `undefined` and `$call.ancestor("scope")`

To do:

- Variable declarations still need to be moved outside the scope of the if statements.This will make the code less compact (especially in c++) however it is a necessity for this topology to work.
- [x] C++
- [ ] C Linux
- [ ] C Windows

WARNING: Not tested in Windows. (Windows :vomiting_face: )