### PR TITLE
Add unaryOp to AstFactory and ClavaJoinPoints

### DIFF
--- a/ClavaAst/src/pt/up/fe/specs/clava/Types.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/Types.java
@@ -15,6 +15,7 @@ package pt.up.fe.specs.clava;
 
 import java.util.Optional;
 
+import pt.up.fe.specs.clava.ast.expr.enums.UnaryOperatorKind;
 import pt.up.fe.specs.clava.ast.type.AdjustedType;
 import pt.up.fe.specs.clava.ast.type.ArrayType;
 import pt.up.fe.specs.clava.ast.type.AttributedType;
@@ -29,8 +30,12 @@ import pt.up.fe.specs.clava.ast.type.PointerType;
 import pt.up.fe.specs.clava.ast.type.QualType;
 import pt.up.fe.specs.clava.ast.type.Type;
 import pt.up.fe.specs.clava.ast.type.TypedefType;
+import pt.up.fe.specs.clava.ast.type.enums.BuiltinKind;
+import pt.up.fe.specs.clava.context.ClavaFactory;
+import pt.up.fe.specs.util.SpecsCheck;
 import pt.up.fe.specs.util.SpecsStrings;
 import pt.up.fe.specs.util.classmap.FunctionClassMap;
+import pt.up.fe.specs.util.exceptions.NotImplementedException;
 
 public class Types {
 
@@ -268,5 +273,36 @@ public class Types {
         }
 
         return type;
+    }
+
+    /**
+     * Tries to infer the return type for a given unary operator.
+     * 
+     * @param op
+     * @param exprType
+     * @return
+     */
+    public static Type inferUnaryType(UnaryOperatorKind op, Type exprType, ClavaFactory factory) {
+        switch (op) {
+        case PostInc:
+        case PostDec:
+        case PreInc:
+        case PreDec:
+        case Not:
+        case Plus:
+        case Minus:
+            return exprType;
+        case LNot:
+            return factory.builtinType(BuiltinKind.Bool);
+        case AddrOf:
+            return factory.pointerType(exprType);
+        case Deref:
+            var desugared = exprType.desugarAll();
+            SpecsCheck.checkArgument(desugared instanceof PointerType,
+                    () -> "Expected type to be a pointer: " + desugared);
+            return ((PointerType) exprType).getPointeeType();
+        default:
+            throw new NotImplementedException("Unary op return type inference not implemented for '" + op + "'");
+        }
     }
 }

--- a/ClavaAst/src/pt/up/fe/specs/clava/ast/expr/BinaryOperator.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ast/expr/BinaryOperator.java
@@ -125,7 +125,7 @@ public class BinaryOperator extends Operator {
         Collections.sort(operators);
 
         var opBySymbol = BinaryOperatorKind.getHelper().getValuesTranslationMap().keySet().stream()
-                .filter(opSym -> !opSym.equals("<UNDEFINED>"))
+                .filter(opSym -> !opSym.equals("<UNDEFINED_BINARY_OP>"))
                 .collect(Collectors.toList());
         Collections.sort(opBySymbol);
 

--- a/ClavaAst/src/pt/up/fe/specs/clava/ast/expr/UnaryOperator.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ast/expr/UnaryOperator.java
@@ -216,4 +216,5 @@ public class UnaryOperator extends Operator {
     public String getOperatorCode() {
         return getOp().getCode();
     }
+
 }

--- a/ClavaAst/src/pt/up/fe/specs/clava/ast/expr/UnaryOperator.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ast/expr/UnaryOperator.java
@@ -26,7 +26,6 @@ import org.suikasoft.jOptions.Datakey.KeyFactory;
 import org.suikasoft.jOptions.Interfaces.DataStore;
 
 import pt.up.fe.specs.clava.ClavaNode;
-import pt.up.fe.specs.clava.ast.expr.enums.BinaryOperatorKind;
 import pt.up.fe.specs.clava.ast.expr.enums.UnaryOperatorKind;
 import pt.up.fe.specs.clava.ast.expr.enums.UnaryOperatorPosition;
 import pt.up.fe.specs.util.lazy.Lazy;
@@ -68,7 +67,7 @@ public class UnaryOperator extends Operator {
         KIND_NAMES.put(UnaryOperatorKind.Extension, "extension");
         KIND_NAMES.put(UnaryOperatorKind.Coawait, "cowait");
     }
-    
+
     private static final Lazy<Map<String, UnaryOperatorKind>> OP_MAP = Lazy.newInstance(UnaryOperator::buildOpMap);
 
     private static Map<String, UnaryOperatorKind> buildOpMap() {
@@ -79,15 +78,15 @@ public class UnaryOperator extends Operator {
 
         return opMap;
     }
-    
+
     public static Map<String, UnaryOperatorKind> getOpMap() {
         return OP_MAP.get();
     }
-    
+
     public static Optional<UnaryOperatorKind> getOpTry(String opName) {
         return Optional.ofNullable(OP_MAP.get().get(opName));
     }
-    
+
     public static UnaryOperatorKind getOpByNameOrSymbol(String op) {
         // First, try by name
         UnaryOperatorKind opKind = UnaryOperator.getOpTry(op).orElse(null);
@@ -109,7 +108,7 @@ public class UnaryOperator extends Operator {
         Collections.sort(operators);
 
         var opBySymbol = UnaryOperatorKind.getEnumHelper().getValuesTranslationMap().keySet().stream()
-                .filter(opSym -> !opSym.equals("<UNDEFINED>"))
+                .filter(opSym -> !opSym.equals("<UNDEFINED_UNARY_OP>"))
                 .collect(Collectors.toList());
         Collections.sort(opBySymbol);
 

--- a/ClavaAst/src/pt/up/fe/specs/clava/ast/expr/enums/BinaryOperatorKind.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ast/expr/enums/BinaryOperatorKind.java
@@ -16,6 +16,7 @@ package pt.up.fe.specs.clava.ast.expr.enums;
 import java.util.EnumSet;
 import java.util.Set;
 
+import pt.up.fe.specs.clava.ClavaLog;
 import pt.up.fe.specs.util.enums.EnumHelperWithValue;
 import pt.up.fe.specs.util.lazy.Lazy;
 import pt.up.fe.specs.util.providers.StringProvider;
@@ -153,7 +154,9 @@ public enum BinaryOperatorKind implements StringProvider {
         case Comma:
             return ",";
         default:
-            return "<UNDEFINED>";
+            // Using debug level to not show messages every time the op map is built
+            ClavaLog.debug("Code not defined for binary operator '" + this + "'");
+            return "<UNDEFINED_BINARY_OP>";
         }
         // return opString;
     }

--- a/ClavaAst/src/pt/up/fe/specs/clava/ast/expr/enums/UnaryOperatorKind.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ast/expr/enums/UnaryOperatorKind.java
@@ -16,8 +16,8 @@ package pt.up.fe.specs.clava.ast.expr.enums;
 import java.util.EnumSet;
 import java.util.Set;
 
+import pt.up.fe.specs.clava.ClavaLog;
 import pt.up.fe.specs.util.enums.EnumHelperWithValue;
-import pt.up.fe.specs.util.exceptions.NotImplementedException;
 import pt.up.fe.specs.util.lazy.Lazy;
 import pt.up.fe.specs.util.providers.StringProvider;
 
@@ -86,7 +86,10 @@ public enum UnaryOperatorKind implements StringProvider {
         case Coawait:
             return "co_await";
         default:
-            throw new NotImplementedException(this);
+            // Using debug level to not show messages every time the op map is built
+            ClavaLog.debug("Code not implemented for unary operator '" + this + "'");
+            return "<UNDEFINED_UNARY_OP>";
+        // throw new NotImplementedException(this);
         }
         // return op;
     }

--- a/ClavaLaraApi/src-lara-clava/clava/clava/ClavaJoinPoints.lara
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/ClavaJoinPoints.lara
@@ -326,6 +326,20 @@ ClavaJoinPoints.binaryOp = function(op, $left, $right, $type) {
 }
 
 /**
+ * Creates a new join point 'unaryOp'. 
+ *
+ * @param {String} op - The unary operator kind.
+ * @param {String|$expr} $expr - The sub-expression of the unary operator. If a string, it is converted to a literal expression.
+ * @param {String|$expr} $type - The return type of the operator. If a string, it is converted to a literal type. If undefined, uses int type.
+ */
+ClavaJoinPoints.unaryOp = function(op, $expr, $type) {
+	$expr = ClavaType.asExpression($expr);
+	$type = ClavaType.asType($type);
+	
+	return AstFactory.unaryOp(op, $expr, $type);
+}
+
+/**
  * Creates a new join point 'expr' representing a parenthesis expression. 
  *
  * @param {String|$expr} $expr - The expression inside the parenthesis. If a string, it is converted to a literal expression.

--- a/ClavaLaraApi/src-lara-clava/clava/clava/ClavaJoinPoints.lara
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/ClavaJoinPoints.lara
@@ -330,11 +330,11 @@ ClavaJoinPoints.binaryOp = function(op, $left, $right, $type) {
  *
  * @param {String} op - The unary operator kind.
  * @param {String|$expr} $expr - The sub-expression of the unary operator. If a string, it is converted to a literal expression.
- * @param {String|$expr} $type - The return type of the operator. If a string, it is converted to a literal type. If undefined, uses int type.
+ * @param {String|$expr} [$type] - The return type of the operator. If a string, it is converted to a literal type. If undefined, tries to infer the correct type based on the type of the $expr (inference might not be implemented for all operators).
  */
 ClavaJoinPoints.unaryOp = function(op, $expr, $type) {
 	$expr = ClavaType.asExpression($expr);
-	$type = ClavaType.asType($type);
+	$type = $type !== undefined ? ClavaType.asType($type) : $type;
 	
 	return AstFactory.unaryOp(op, $expr, $type);
 }

--- a/ClavaWeaver/resources/clava/test/api/ClavaJoinPointsTest.lara
+++ b/ClavaWeaver/resources/clava/test/api/ClavaJoinPointsTest.lara
@@ -5,6 +5,8 @@ aspectdef ClavaJoinPointsTest
 	var intType = ClavaJoinPoints.builtinType("int");
 	var doubleType = ClavaJoinPoints.builtinType("double");
 	var intExpr = ClavaJoinPoints.exprLiteral("a", intType);
+	var intPointerType = ClavaJoinPoints.pointer(intType);
+	var intPointerExpr = ClavaJoinPoints.exprLiteral("aPointer", intPointerType);
 
 	// Type Literal of user defined type
 	println("User literal type: " + ClavaJoinPoints.typeLiteral("xpto").code);
@@ -30,4 +32,13 @@ aspectdef ClavaJoinPointsTest
 	// For Stmt
 	println("Empty for:\n" + ClavaJoinPoints.forStmt().code);
 	println("Complete for:\n" + ClavaJoinPoints.forStmt("int i=0;", "i<10;", "i++;", "i = i+1;\ni = i - 1;").code);	
+	
+	// Unary Operator
+	var addressOfOp = ClavaJoinPoints.unaryOp("&", intExpr);
+	println("AddressOf code: " + addressOfOp.code);
+	println("AddressOf code type: " + addressOfOp.type.code);
+	
+	var derefOp = ClavaJoinPoints.unaryOp("*", intPointerExpr);
+	println("Deref code: " + derefOp.code);
+	println("Deref code type: " + derefOp.type.code);
 end

--- a/ClavaWeaver/resources/clava/test/api/cpp/results/ClavaJoinPointsTest.lara.txt
+++ b/ClavaWeaver/resources/clava/test/api/cpp/results/ClavaJoinPointsTest.lara.txt
@@ -26,3 +26,7 @@ for(int i=0; i<10; i++) {
    i = i+1;
    i = i - 1;
 }
+AddressOf code: &a
+AddressOf code type: int *
+Deref code: *aPointer
+Deref code type: int

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/importable/AstFactory.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/importable/AstFactory.java
@@ -27,6 +27,7 @@ import pt.up.fe.specs.clava.ClavaLog;
 import pt.up.fe.specs.clava.ClavaNode;
 import pt.up.fe.specs.clava.ClavaNodes;
 import pt.up.fe.specs.clava.ClavaOptions;
+import pt.up.fe.specs.clava.Types;
 import pt.up.fe.specs.clava.ast.decl.Decl;
 import pt.up.fe.specs.clava.ast.decl.FieldDecl;
 import pt.up.fe.specs.clava.ast.decl.FunctionDecl;
@@ -681,12 +682,19 @@ public class AstFactory {
 
         return CxxJoinpoints.create(opNode, ABinaryOp.class);
     }
-    
+
     public static AUnaryOp unaryOp(String op, AExpression expr, AType type) {
+
+        System.out.println("TYPE: " + type);
 
         UnaryOperatorKind opKind = UnaryOperator.getOpByNameOrSymbol(op);
 
-        UnaryOperator opNode = CxxWeaver.getFactory().unaryOperator(opKind, (Type) type.getNode(),
+        // If type is null, try to infer type from operator
+        var typeNode = type != null ? (Type) type.getNode()
+                : Types.inferUnaryType(opKind, (Type) expr.getTypeImpl().getNode(), CxxWeaver.getFactory());
+
+        // UnaryOperator opNode = CxxWeaver.getFactory().unaryOperator(opKind, (Type) type.getNode(),
+        UnaryOperator opNode = CxxWeaver.getFactory().unaryOperator(opKind, typeNode,
                 (Expr) expr.getNode());
 
         return CxxJoinpoints.create(opNode, AUnaryOp.class);

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/importable/AstFactory.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/importable/AstFactory.java
@@ -44,8 +44,10 @@ import pt.up.fe.specs.clava.ast.expr.Expr;
 import pt.up.fe.specs.clava.ast.expr.FloatingLiteral;
 import pt.up.fe.specs.clava.ast.expr.IntegerLiteral;
 import pt.up.fe.specs.clava.ast.expr.ParenExpr;
+import pt.up.fe.specs.clava.ast.expr.UnaryOperator;
 import pt.up.fe.specs.clava.ast.expr.enums.BinaryOperatorKind;
 import pt.up.fe.specs.clava.ast.expr.enums.FloatKind;
+import pt.up.fe.specs.clava.ast.expr.enums.UnaryOperatorKind;
 import pt.up.fe.specs.clava.ast.extra.TranslationUnit;
 import pt.up.fe.specs.clava.ast.omp.OmpDirectiveKind;
 import pt.up.fe.specs.clava.ast.stmt.BreakStmt;
@@ -91,6 +93,7 @@ import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.AStatement;
 import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.AStruct;
 import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.AType;
 import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.ATypedefDecl;
+import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.AUnaryOp;
 import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.AVardecl;
 import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.AVarref;
 import pt.up.fe.specs.clava.weaver.joinpoints.CxxFunction;
@@ -677,6 +680,16 @@ public class AstFactory {
                 (Expr) left.getNode(), (Expr) right.getNode());
 
         return CxxJoinpoints.create(opNode, ABinaryOp.class);
+    }
+    
+    public static AUnaryOp unaryOp(String op, AExpression expr, AType type) {
+
+        UnaryOperatorKind opKind = UnaryOperator.getOpByNameOrSymbol(op);
+
+        UnaryOperator opNode = CxxWeaver.getFactory().unaryOperator(opKind, (Type) type.getNode(),
+                (Expr) expr.getNode());
+
+        return CxxJoinpoints.create(opNode, AUnaryOp.class);
     }
 
     public static AExpression parenthesis(AExpression expression) {

--- a/ClavaWeaver/test/pt/up/fe/specs/cxxweaver/tests/CxxTest.java
+++ b/ClavaWeaver/test/pt/up/fe/specs/cxxweaver/tests/CxxTest.java
@@ -314,4 +314,5 @@ public class CxxTest {
     public void testFunction2() {
         newTester().test("Function2.lara", "function2.cpp");
     }
+
 }


### PR DESCRIPTION
Replicates `binaryOp` code to add support for the creation of `unaryOp` joinpoints using the `ClavaJoinPoints` API

NOT THOROUGHLY TESTED!!!
Did not add any unit tests.