### PR TITLE
Add SingleFunctionReturn pass

### DIFF
--- a/ClavaLaraApi/src-lara-clava/clava/clava/pass/SingleReturnFunction.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/pass/SingleReturnFunction.js
@@ -1,0 +1,41 @@
+laraImport("lara.pass.Pass");
+laraImport("weaver.Query");
+
+class SingleReturnFunction extends Pass {
+  constructor() {
+    super("SingleReturnFunction");
+  }
+
+  _apply_impl($jp) {
+    if ($jp.joinpointType !== "function" || !$jp.isImplementation) {
+      return;
+    }
+    const $body = $jp.body;
+    const $returnStmts = Array.from(Query.searchFrom($body, "returnStmt"));
+    if ($returnStmts.length <= 1) {
+      return;
+    }
+
+    $body.insertEnd("__returnLabel:");
+
+    const returnType = $jp.returnType;
+    const returnIsVoid =
+      !returnType.isBuiltin || returnType.builtinKind !== "Void";
+    if (returnIsVoid) {
+      $body.addLocal("__returnValue", returnType);
+      $body.insertEnd("return __returnValue;");
+    } else {
+      $body.insertEnd(";");
+    }
+
+    for (const $returnStmt of $returnStmts) {
+      if (returnIsVoid) {
+        $returnStmt.insertBefore(
+          `__return_value = ${$returnStmt.returnExpr.code};`
+        );
+      }
+      $returnStmt.insertBefore("goto __returnLabel;");
+      $returnStmt.detach();
+    }
+  }
+}


### PR DESCRIPTION
Add pass to Clava's normalization utilities API that transforms a function that has multiple returns into a function that has a single
return.

Does so by inserting a label at the end of the function with a single return statement, and replaces existing returns with an assignment to a return variable and a jump to the label.