### PR TITLE
[ClavaLaraApi] ref: Tweak passes

### DIFF
--- a/ClavaLaraApi/src-lara-clava/clava/clava/pass/DecomposeDeclStmt.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/pass/DecomposeDeclStmt.js
@@ -24,9 +24,8 @@ class DecomposeDeclStmt extends Pass {
   }
 
   _apply_impl($jp) {
+    let appliedPass = false;
 
-	let appliedPass = false;
-	
     // Find all declaration statements
     for (const $declStmt of Query.searchFromInclusive($jp, "declStmt")) {
       // Ignore statement if it only declares one variable
@@ -34,8 +33,8 @@ class DecomposeDeclStmt extends Pass {
         continue;
       }
 
-	  // Found declStmt to decompose
-	  appliedPass = true;
+      // Found declStmt to decompose
+      appliedPass = true;
 
       // Create new statement for each declaration
       // Insert it before the old node to preserve the order of declarations
@@ -46,16 +45,11 @@ class DecomposeDeclStmt extends Pass {
       // Remove the old statement
       $declStmt.detach();
     }
-    
-	return this._new_result($jp, appliedPass);
+
+    return new PassResult(this.name, {
+      appliedPass,
+      insertedLiteralCode: false,
+      location: $jp.location,
+    });
   }
-  
-  _new_result($jp, appliedPass) {
-		var result = new PassResult(this.name);
-		result.isUndefined = false;
-		result.appliedPass = appliedPass;
-		result.insertedLiteralCode = false;
-		result.location = $jp.location;
-		return result;
-	}
 }

--- a/ClavaLaraApi/src-lara-clava/clava/clava/pass/SingleReturnFunction.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/pass/SingleReturnFunction.js
@@ -47,6 +47,7 @@ class SingleReturnFunction extends Pass {
     for (const $returnStmt of $returnStmts) {
       if (!returnIsVoid) {
         $returnStmt.insertBefore(
+          // null safety: $local is initialized whenever return is not void
           assign(varRef($local), $returnStmt.returnExpr)
         );
       }

--- a/ClavaLaraApi/src-lara-clava/clava/clava/pass/SingleReturnFunction.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/pass/SingleReturnFunction.js
@@ -17,7 +17,7 @@ class SingleReturnFunction extends Pass {
       $returnStmts.length === 0 ||
       ($returnStmts.length === 1 && $body.lastChild.instanceOf("returnStmt"))
     ) {
-      return this._new_result($jp, false);
+      return this.#new_result($jp, false);
     }
 
     // C++ spec has some restrictions about jumping over initialized values that
@@ -46,16 +46,15 @@ class SingleReturnFunction extends Pass {
       $returnStmt.insertBefore("goto __return_label;");
       $returnStmt.detach();
     }
-    
-    return this._new_result($jp, true);
+
+    return this.#new_result($jp, true);
   }
-  
-  _new_result($jp, appliedPass) {
-		var result = new PassResult(this.name);
-		result.isUndefined = false;
-		result.appliedPass = appliedPass;
-		result.insertedLiteralCode = true;
-		result.location = $jp.location;
-		return result;
-	}  
+
+  #new_result($jp, appliedPass) {
+    return new PassResult(this.name, {
+      appliedPass,
+      insertedLiteralCode: true,
+      location: $jp.location,
+    });
+  }
 }

--- a/ClavaWeaver/resources/clava/test/api/cpp/results/PassSingleReturnTest.js.txt
+++ b/ClavaWeaver/resources/clava/test/api/cpp/results/PassSingleReturnTest.js.txt
@@ -47,7 +47,7 @@ void earlyReturn(double n) {
    }
    std::cout << "Not greater than 16" << std::endl;
    __return_label:
-   ;
+   return;
 }
 
 /**** End File ****/


### PR DESCRIPTION
Some improvements and tweaks to existing Clava transformation passes.

- Use options object in PassResult constructor instead of setters to simplify result building
- Transition SingleReturnFunction pass from inserting code literals to using ClavaJoinPoints