### PR TITLE
[ClavaLaraApi] Add transform from ternary op assignment to if-else

### DIFF
--- a/ClavaLaraApi/src-java/pt/up/fe/specs/clava/weaver/LaraApiResource.java
+++ b/ClavaLaraApi/src-java/pt/up/fe/specs/clava/weaver/LaraApiResource.java
@@ -79,6 +79,7 @@ public enum LaraApiResource implements LaraResourceProvider {
     STATEMENT_DECOMPOSER_JS("code/StatementDecomposer.js"),
     DECOMPOSE_RESULT_JS("code/DecomposeResult.js"),
     CODE_SIMPLIFY_ASSIGNMENT("code/SimplifyAssignment.js"),
+    CODE_SIMPLIFY_TERNARY_OP("code/SimplifyTernaryOp.js"),
 
     // Gprofer
     GPROFER("gprofer/Gprofer.lara"),

--- a/ClavaLaraApi/src-lara-clava/clava/clava/code/SimplifyTernaryOp.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/code/SimplifyTernaryOp.js
@@ -1,0 +1,57 @@
+laraImport("clava.ClavaJoinPoints");
+
+class SimplifyTernaryOp {
+  /**
+   * Simplifies a statement like:
+   *
+   * ```c
+   * x = y ? a : b;
+   * ```
+   *
+   * Into:
+   *
+   * ```c
+   * if (y) {
+   *    x = a;
+   * } else {
+   *    x = b;
+   * }
+   * ```
+   *
+   * $assignmentStmt must be an expression statement (not an inline expression, such as in a
+   * varDecl or within another expression). The expression statement must only contain an assignment
+   * operator, and the rvalue must be a ternary operator.
+   *
+   * Otherwise the function will immediately return.
+   *
+   * @param {exprStmt} $assignmentStmt Expression statement containing an assignment where the right hand side is a ternary operator
+   * @returns {undefined}
+   */
+  static apply($assignmentStmt) {
+    // early return if current node is not suitable
+    const applicable =
+      $assignmentStmt.instanceOf("exprStmt") &&
+      $assignmentStmt.expr.instanceOf("binaryOp") &&
+      $assignmentStmt.expr.isAssignment &&
+      $assignmentStmt.expr.right.instanceOf("ternaryOp");
+    if (!applicable) {
+      return;
+    }
+    const $assignment = $assignmentStmt.expr;
+    const $ternaryOp = $assignment.right;
+
+    const $trueStmt = $assignmentStmt.copy();
+    $trueStmt.expr.right = $ternaryOp.trueExpr;
+
+    const $falseStmt = $assignmentStmt.copy();
+    $falseStmt.expr.right = $ternaryOp.falseExpr;
+
+    const $ifStmt = ClavaJoinPoints.ifStmt(
+      $ternaryOp.cond,
+      ClavaJoinPoints.scope([$trueStmt]),
+      ClavaJoinPoints.scope([$falseStmt])
+    );
+
+    $assignmentStmt.replaceWith($ifStmt);
+  }
+}

--- a/ClavaWeaver/resources/clava/test/api/CodeSimplifyTernaryOpTest.js
+++ b/ClavaWeaver/resources/clava/test/api/CodeSimplifyTernaryOpTest.js
@@ -1,0 +1,10 @@
+laraImport("clava.Clava");
+laraImport("clava.code.SimplifyTernaryOp");
+laraImport("weaver.Query");
+
+for ($stmt of Query.search("exprStmt")) {
+  SimplifyTernaryOp.apply($stmt);
+}
+
+Clava.rebuild();
+println(Query.root().code);

--- a/ClavaWeaver/resources/clava/test/api/cpp/results/CodeSimplifyTernaryOpTest.js.txt
+++ b/ClavaWeaver/resources/clava/test/api/cpp/results/CodeSimplifyTernaryOpTest.js.txt
@@ -1,0 +1,21 @@
+/**** File 'cxx_weaver_output/code_simplify_ternary_op.cpp' ****/
+int main() {
+bool b = true;
+int i = b ? 1 : 0;
+int j;
+if(i > 0) {
+j = 2;
+}
+else {
+j = 4;
+}
+int k;
+if(b) {
+k += 1;
+}
+else {
+k += 0;
+}
+return 0;
+}
+/**** End File ****/

--- a/ClavaWeaver/resources/clava/test/api/cpp/src/code_simplify_ternary_op.cpp
+++ b/ClavaWeaver/resources/clava/test/api/cpp/src/code_simplify_ternary_op.cpp
@@ -1,0 +1,14 @@
+int main(void)
+{
+    bool b = true;
+
+    int i = b ? 1 : 0;
+
+    int j;
+    j = i > 0 ? 2 : 4;
+
+    int k;
+    k += b ? 1 : 0;
+
+    return 0;
+}

--- a/ClavaWeaver/test/pt/up/fe/specs/cxxweaver/tests/CxxApiTest.java
+++ b/ClavaWeaver/test/pt/up/fe/specs/cxxweaver/tests/CxxApiTest.java
@@ -175,4 +175,9 @@ public class CxxApiTest {
     public void testSimplifyAssignment() {
         newTester().test("CodeSimplifyAssignmentTest.js", "code_simplify_assignment.cpp");
     }
+
+    @Test
+    public void testSimplifyTernaryOp() {
+        newTester().test("CodeSimplifyTernaryOpTest.js", "code_simplify_ternary_op.cpp");
+    }
 }


### PR DESCRIPTION
Simplifies a statement like:
```c
x = y ? a : b;
```

Into:
```c
if (y) {
  x = a;
} else {
  x = b;
}
```

The target statement must be an expression statement, containing exactly
an assignment operator, whose rvalue must be a ternary operator.
Otherwise returns without side-effects.