### PR TITLE
[ClavaLaraApi] ref(clava.code.Simplify*): Export functions instead of single-method classes

### DIFF
--- a/ClavaLaraApi/src-lara-clava/clava/clava/code/SimplifyAssignment.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/code/SimplifyAssignment.js
@@ -1,40 +1,43 @@
 laraImport("clava.ClavaJoinPoints");
 
-class SimplifyAssignment {
-  /**
-   * Non-assignment counterparts of complex assignment operators (lookup table)
-   */
-  static #ops = new Map([
-    ["*=", "*"],
-    ["/=", "/"],
-    ["%=", "%"],
-    ["+=", "+"],
-    ["-=", "-"],
-    ["<<=", "<<"],
-    [">>=", ">>"],
-    ["&=", "&"],
-    ["^=", "^"],
-    ["|=", "|"],
-  ]);
-
-  static apply($complexAssignment) {
-    // early return if current node is not suitable for this transform
-    if (
-      !$complexAssignment.instanceOf("binaryOp") ||
-      !this.#ops.has($complexAssignment.operator)
-    ) {
-      return;
-    }
-
-    const $lValue = $complexAssignment.left;
-    const $rValue = $complexAssignment.right;
-
-    const $binaryOp = ClavaJoinPoints.binaryOp(
-      this.#ops.get($complexAssignment.operator),
-      $lValue.copy(),
-      $rValue,
-      $complexAssignment.type
-    );
-    $complexAssignment.replaceWith(ClavaJoinPoints.assign($lValue, $binaryOp));
+/**
+ * Simplifies assignments of the type `a += b` into the equivalent expression `a = a + b`
+ * @param {$binaryOp} $complexAssignment The expression to simplify
+ */
+function SimplifyAssignment($complexAssignment) {
+  // early return if current node is not suitable for this transform
+  if (
+    !$complexAssignment ||
+    !$complexAssignment.instanceOf("binaryOp") ||
+    !SimplifyAssignment._ops.has($complexAssignment.operator)
+  ) {
+    return;
   }
+
+  const $lValue = $complexAssignment.left;
+  const $rValue = $complexAssignment.right;
+
+  const $binaryOp = ClavaJoinPoints.binaryOp(
+    SimplifyAssignment._ops.get($complexAssignment.operator),
+    $lValue.copy(),
+    $rValue,
+    $complexAssignment.type
+  );
+  $complexAssignment.replaceWith(ClavaJoinPoints.assign($lValue, $binaryOp));
 }
+
+/**
+ * Non-assignment counterparts of complex assignment operators (lookup table)
+ */
+SimplifyAssignment._ops = new Map([
+  ["*=", "*"],
+  ["/=", "/"],
+  ["%=", "%"],
+  ["+=", "+"],
+  ["-=", "-"],
+  ["<<=", "<<"],
+  [">>=", ">>"],
+  ["&=", "&"],
+  ["^=", "^"],
+  ["|=", "|"],
+]);

--- a/ClavaLaraApi/src-lara-clava/clava/clava/code/SimplifyTernaryOp.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/code/SimplifyTernaryOp.js
@@ -1,57 +1,54 @@
 laraImport("clava.ClavaJoinPoints");
 
-class SimplifyTernaryOp {
-  /**
-   * Simplifies a statement like:
-   *
-   * ```c
-   * x = y ? a : b;
-   * ```
-   *
-   * Into:
-   *
-   * ```c
-   * if (y) {
-   *    x = a;
-   * } else {
-   *    x = b;
-   * }
-   * ```
-   *
-   * $assignmentStmt must be an expression statement (not an inline expression, such as in a
-   * varDecl or within another expression). The expression statement must only contain an assignment
-   * operator, and the rvalue must be a ternary operator.
-   *
-   * Otherwise the function will immediately return.
-   *
-   * @param {exprStmt} $assignmentStmt Expression statement containing an assignment where the right hand side is a ternary operator
-   * @returns {undefined}
-   */
-  static apply($assignmentStmt) {
-    // early return if current node is not suitable
-    const applicable =
-      $assignmentStmt.instanceOf("exprStmt") &&
-      $assignmentStmt.expr.instanceOf("binaryOp") &&
-      $assignmentStmt.expr.isAssignment &&
-      $assignmentStmt.expr.right.instanceOf("ternaryOp");
-    if (!applicable) {
-      return;
-    }
-    const $assignment = $assignmentStmt.expr;
-    const $ternaryOp = $assignment.right;
-
-    const $trueStmt = $assignmentStmt.copy();
-    $trueStmt.expr.right = $ternaryOp.trueExpr;
-
-    const $falseStmt = $assignmentStmt.copy();
-    $falseStmt.expr.right = $ternaryOp.falseExpr;
-
-    const $ifStmt = ClavaJoinPoints.ifStmt(
-      $ternaryOp.cond,
-      ClavaJoinPoints.scope([$trueStmt]),
-      ClavaJoinPoints.scope([$falseStmt])
-    );
-
-    $assignmentStmt.replaceWith($ifStmt);
+/**
+ * Simplifies a statement like:
+ *
+ * ```c
+ * x = y ? a : b;
+ * ```
+ *
+ * Into:
+ *
+ * ```c
+ * if (y) {
+ *    x = a;
+ * } else {
+ *    x = b;
+ * }
+ * ```
+ *
+ * $assignmentStmt must be an expression statement (not an inline expression, such as in a
+ * varDecl or within another expression). The expression statement must only contain an assignment
+ * operator, and the rvalue must be a ternary operator.
+ *
+ * Otherwise the function will immediately return.
+ *
+ * @param {$exprStmt} $assignmentStmt Expression statement containing an assignment where the right hand side is a ternary operator
+ */
+function SimplifyTernaryOp($assignmentStmt) {
+  // early return if current node is not suitable
+  const applicable =
+    $assignmentStmt.instanceOf("exprStmt") &&
+    $assignmentStmt.expr.instanceOf("binaryOp") &&
+    $assignmentStmt.expr.isAssignment &&
+    $assignmentStmt.expr.right.instanceOf("ternaryOp");
+  if (!applicable) {
+    return;
   }
+  const $assignment = $assignmentStmt.expr;
+  const $ternaryOp = $assignment.right;
+
+  const $trueStmt = $assignmentStmt.copy();
+  $trueStmt.expr.right = $ternaryOp.trueExpr;
+
+  const $falseStmt = $assignmentStmt.copy();
+  $falseStmt.expr.right = $ternaryOp.falseExpr;
+
+  const $ifStmt = ClavaJoinPoints.ifStmt(
+    $ternaryOp.cond,
+    ClavaJoinPoints.scope([$trueStmt]),
+    ClavaJoinPoints.scope([$falseStmt])
+  );
+
+  $assignmentStmt.replaceWith($ifStmt);
 }

--- a/ClavaWeaver/resources/clava/test/api/CodeSimplifyAssignmentTest.js
+++ b/ClavaWeaver/resources/clava/test/api/CodeSimplifyAssignmentTest.js
@@ -3,7 +3,7 @@ laraImport("clava.code.SimplifyAssignment");
 laraImport("weaver.Query");
 
 for (const $op of Query.search("binaryOp")) {
-  SimplifyAssignment.apply($op);
+  SimplifyAssignment($op);
 }
 
 Clava.rebuild();

--- a/ClavaWeaver/resources/clava/test/api/CodeSimplifyTernaryOpTest.js
+++ b/ClavaWeaver/resources/clava/test/api/CodeSimplifyTernaryOpTest.js
@@ -3,7 +3,7 @@ laraImport("clava.code.SimplifyTernaryOp");
 laraImport("weaver.Query");
 
 for ($stmt of Query.search("exprStmt")) {
-  SimplifyTernaryOp.apply($stmt);
+  SimplifyTernaryOp($stmt);
 }
 
 Clava.rebuild();


### PR DESCRIPTION
In clava.code.SimplifyAssignment and clava.code.SimplifyTernaryOp, export
a single function instead of a class with a single static member.
SimplifyAssignment.#ops private member is moved to a property of the
function.

TODO: when ES modules support is implemented, SimplifyAssignment._ops
should be a top-level, non-exported constant.