### PR TITLE
Add Ternary Operator creation methods to Clava factories

### DIFF
--- a/ClavaAst/src/pt/up/fe/specs/clava/context/ClavaFactory.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/context/ClavaFactory.java
@@ -65,6 +65,7 @@ import pt.up.fe.specs.clava.ast.expr.CXXConstructExpr;
 import pt.up.fe.specs.clava.ast.expr.CXXFunctionalCastExpr;
 import pt.up.fe.specs.clava.ast.expr.CallExpr;
 import pt.up.fe.specs.clava.ast.expr.CastExpr;
+import pt.up.fe.specs.clava.ast.expr.ConditionalOperator;
 import pt.up.fe.specs.clava.ast.expr.DeclRefExpr;
 import pt.up.fe.specs.clava.ast.expr.DummyExpr;
 import pt.up.fe.specs.clava.ast.expr.Expr;
@@ -424,6 +425,13 @@ public class ClavaFactory {
             data.put(UnaryOperator.POSITION, UnaryOperatorPosition.POSTFIX);
 
         return new UnaryOperator(data, Arrays.asList(subExpr));
+    }
+
+    public ConditionalOperator conditionalOperator(Type type, Expr condition, Expr trueExpr, Expr falseExpr) {
+        DataStore data = newDataStore(ConditionalOperator.class)
+                .put(Expr.TYPE, Optional.of(type));
+
+        return new ConditionalOperator(data, Arrays.asList(condition, trueExpr, falseExpr));
     }
 
     public CStyleCastExpr cStyleCastExpr(Type type, Expr expr) {

--- a/ClavaLaraApi/src-lara-clava/clava/clava/ClavaJoinPoints.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/ClavaJoinPoints.js
@@ -363,6 +363,24 @@ class ClavaJoinPoints {
   }
 
   /**
+   * Creates a new join point 'ternaryOp'
+   *
+   * @param {$expr|string} $cond The condition of the operator
+   * @param {$expr|string} $trueExpr The result when $cond evaluates to true
+   * @param {$expr|string} $falseExpr The result when $cond evaluates to false
+   * @param {$type|string} $type The type of the operation
+   * @returns {$ternaryOp} The newly created join point
+   */
+  static ternaryOp($cond, $trueExpr, $falseExpr, $type) {
+    $cond = ClavaType.asExpression($cond);
+    $trueExpr = ClavaType.asExpression($trueExpr);
+    $falseExpr = ClavaType.asExpression($falseExpr);
+    $type = ClavaType.asType($type);
+
+    return AstFactory.ternaryOp($cond, $trueExpr, $falseExpr, $type);
+  }
+
+  /**
    * Creates a new join point 'expr' representing a parenthesis expression.
    *
    * @param {String|$expr} $expr - The expression inside the parenthesis. If a string, it is converted to a literal expression.

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/importable/AstFactory.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/importable/AstFactory.java
@@ -41,6 +41,7 @@ import pt.up.fe.specs.clava.ast.decl.VarDecl;
 import pt.up.fe.specs.clava.ast.decl.enums.LanguageId;
 import pt.up.fe.specs.clava.ast.expr.BinaryOperator;
 import pt.up.fe.specs.clava.ast.expr.CallExpr;
+import pt.up.fe.specs.clava.ast.expr.ConditionalOperator;
 import pt.up.fe.specs.clava.ast.expr.DeclRefExpr;
 import pt.up.fe.specs.clava.ast.expr.Expr;
 import pt.up.fe.specs.clava.ast.expr.FloatingLiteral;
@@ -99,6 +100,7 @@ import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.AParam;
 import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.AScope;
 import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.AStatement;
 import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.AStruct;
+import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.ATernaryOp;
 import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.AType;
 import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.ATypedefDecl;
 import pt.up.fe.specs.clava.weaver.abstracts.joinpoints.AUnaryOp;
@@ -622,6 +624,16 @@ public class AstFactory {
                 (Expr) expr.getNode());
 
         return CxxJoinpoints.create(opNode, AUnaryOp.class);
+    }
+
+    public static ATernaryOp ternaryOp(AExpression cond, AExpression trueExpr, AExpression falseExpr, AType type) {
+        ConditionalOperator opNode = CxxWeaver.getFactory().conditionalOperator(
+                (Type) type.getNode(),
+                (Expr) cond.getNode(),
+                (Expr) trueExpr.getNode(),
+                (Expr) falseExpr.getNode());
+
+        return CxxJoinpoints.create(opNode, ATernaryOp.class);
     }
 
     public static AExpression parenthesis(AExpression expression) {


### PR DESCRIPTION
Add ternary op creation support to ClavaFactory, AstFactory and ClavaJoinpoints

Use case example:

Input:
```c
int main(void)
{
}
```

Aspect:
```js
laraImport("weaver.Query");
laraImport("clava.ClavaJoinPoints");

for (const f of Query.search("function", "main")) {
  f.body.addLocal("a", ClavaJoinPoints.builtinType("int"));
  f.body.insertEnd(
    ClavaJoinPoints.exprStmt(
      ClavaJoinPoints.assign(
        ClavaJoinPoints.varRef("a", ClavaJoinPoints.builtinType("int")),
        ClavaJoinPoints.ternaryOp(
          "1 == 1",
          "1",
          "0",
          ClavaJoinPoints.builtinType("int")
        )
      )
    )
  );
}
```

Output:
```
int main() {
   int a;
   a = 1 == 1 ? 1 : 0;
}
```