### PR TITLE
fix(ClavaWeaver): Use type of `lhs` on AstFactory.assignment as Expr type

### DIFF
--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/importable/AstFactory.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/importable/AstFactory.java
@@ -589,7 +589,7 @@ public class AstFactory {
         Expr lhs = (Expr) leftHand.getNode();
         Expr rhs = (Expr) rightHand.getNode();
 
-        BinaryOperator assign = CxxWeaver.getFactory().binaryOperator(BinaryOperatorKind.Assign, rhs.getType(), lhs,
+        BinaryOperator assign = CxxWeaver.getFactory().binaryOperator(BinaryOperatorKind.Assign, lhs.getType(), lhs,
                 rhs);
 
         return CxxJoinpoints.create(assign, ABinaryOp.class);


### PR DESCRIPTION
In C and C++, the value/type of an assignment is that of the lvalue after it has been assigned.

The code in AstFactory.assignment was using the type of the rvalue to create the node, instead of
the lvalue. Correct that.