### PR TITLE
Inliner fix - Array params and return statements

### DIFF
--- a/ClavaLaraApi/src-java/pt/up/fe/specs/clava/weaver/LaraApiResource.java
+++ b/ClavaLaraApi/src-java/pt/up/fe/specs/clava/weaver/LaraApiResource.java
@@ -144,6 +144,7 @@ public enum LaraApiResource implements LaraResourceProvider {
     DECOMPOSE_VAR_DECLARATIONS("pass/DecomposeVarDeclarations.js"),
     SINGLE_RETURN_FUNCTION("pass/SingleReturnFunction.js"),
     PASS_SIMPLIFY_LOOPS("pass/SimplifyLoops.js"),
+    PASS_SIMPLIFY_RETURN("pass/SimplifyReturnStmts.js"),
     PASS_SIMPLIFY_SELECTION_STMTS("pass/SimplifySelectionStmts.js"),
 
     // Stats

--- a/ClavaLaraApi/src-lara-clava/clava/clava/code/StatementDecomposer.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/code/StatementDecomposer.js
@@ -68,6 +68,9 @@ class StatementDecomposer {
   decomposeStmt($stmt) {
     // Unsupported
     if ($stmt.instanceOf("scope") || $stmt.joinPointType === "statement") {
+      debug(
+        `StatementDecomposer: unsupported statement with code ${$stmt.code}`
+      );
       return [];
     }
 

--- a/ClavaLaraApi/src-lara-clava/clava/clava/opt/NormalizeToSubset.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/opt/NormalizeToSubset.js
@@ -4,6 +4,7 @@ laraImport("clava.pass.SimplifyLoops");
 laraImport("clava.pass.DecomposeVarDeclarations");
 laraImport("clava.pass.DecomposeDeclStmt");
 laraImport("clava.pass.SimplifySelectionStmts");
+laraImport("clava.pass.SimplifyReturnStmts");
 laraImport("clava.code.SimplifyAssignment");
 
 /**
@@ -23,9 +24,11 @@ function NormalizeToSubset($startJp, options) {
     _options["simplifyLoops"]
   );
   const simplifyIfs = new SimplifySelectionStmts(statementDecomposer);
+  const simplifyReturns = new SimplifyReturnStmts(statementDecomposer);
 
   simplifyLoops.apply($startJp);
   simplifyIfs.apply($startJp);
+  simplifyReturns.apply($startJp);
 
   declStmt.apply($startJp);
   varDecls.apply($startJp);

--- a/ClavaLaraApi/src-lara-clava/clava/clava/pass/SimplifyReturnStmts.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/pass/SimplifyReturnStmts.js
@@ -1,0 +1,41 @@
+laraImport("lara.pass.Pass");
+laraImport("clava.code.StatementDecomposer");
+laraImport("weaver.Query");
+
+class SimplifyReturnStmts extends Pass {
+  #statementDecomposer;
+
+  constructor(statementDecomposer) {
+    super("SimplifyReturnStmts");
+    this.#statementDecomposer = statementDecomposer;
+  }
+
+  _apply_impl($jp) {
+    let appliedPass = false;
+    for (const $returnStmt of this.#findStmts($jp)) {
+      appliedPass = true;
+      this.#transform($returnStmt);
+    }
+
+    return new PassResult(this.name, {
+      appliedPass,
+      insertedLiteralCode: false,
+      location: $jp.location,
+    });
+  }
+
+  #findStmts($jp) {
+    return Query.searchFromInclusive($jp, "returnStmt");
+  }
+
+  #transform($returnStmt) {
+    const decomposeResult = this.#statementDecomposer.decompose($returnStmt);
+
+    // Returns a list of stmts, replace with current return
+    for (const stmt of decomposeResult) {
+      $returnStmt.insertBefore(stmt);
+    }
+
+    $returnStmt.detach();
+  }
+}

--- a/ClavaWeaver/resources/clava/test/api/InlinerTest.js
+++ b/ClavaWeaver/resources/clava/test/api/InlinerTest.js
@@ -7,6 +7,8 @@ laraImport("clava.opt.PrepareForInlining");
 laraImport("weaver.WeaverJps");
 laraImport("weaver.Query");
 
+//setDebug(true);
+
 // Normalize all code
 NormalizeToSubset(Query.root());
 
@@ -41,3 +43,8 @@ new Inliner().inlineFunctionTree(
   Query.search("function", "inlineTest2").first()
 );
 println(Query.search("function", "inlineTest2").first().code);
+
+new Inliner().inlineFunctionTree(
+  Query.search("function", "arrayParam").first()
+);
+println(Query.search("function", "arrayParam").first().code);

--- a/ClavaWeaver/resources/clava/test/api/c/results/InlinerTest.js.txt
+++ b/ClavaWeaver/resources/clava/test/api/c/results/InlinerTest.js.txt
@@ -52,7 +52,11 @@ int main() {
                   int __inline_3___inline_1_x;
                   __inline_3___inline_1_x = __inline_3_Y[__inline_3_i];
                   {
-                     __inline_3_Y[__inline_3_i] = __inline_3___inline_1_x * __inline_3___inline_1_x * __inline_3___inline_1_x;
+                     int __inline_3___inline_1_decomp_9;
+                     __inline_3___inline_1_decomp_9 = __inline_3___inline_1_x * __inline_3___inline_1_x;
+                     int __inline_3___inline_1_decomp_10;
+                     __inline_3___inline_1_decomp_10 = __inline_3___inline_1_decomp_9 * __inline_3___inline_1_x;
+                     __inline_3_Y[__inline_3_i] = __inline_3___inline_1_decomp_10;
                   }
                }
                __inline_3_i++;
@@ -70,14 +74,20 @@ int main() {
                   int __inline_3___inline_2_x;
                   __inline_3___inline_2_x = __inline_3_Y[__inline_3_i];
                   {
-                     __inline_3_Y[__inline_3_i] = __inline_3___inline_2_x * __inline_3___inline_2_x * __inline_3___inline_2_x;
+                     int __inline_3___inline_2_decomp_9;
+                     __inline_3___inline_2_decomp_9 = __inline_3___inline_2_x * __inline_3___inline_2_x;
+                     int __inline_3___inline_2_decomp_10;
+                     __inline_3___inline_2_decomp_10 = __inline_3___inline_2_decomp_9 * __inline_3___inline_2_x;
+                     __inline_3_Y[__inline_3_i] = __inline_3___inline_2_decomp_10;
                   }
                }
                __inline_3_i++;
                __inline_3_decomp_3 = __inline_3_i < 100;
             }
          }
-         x = __inline_3_X[0] + __inline_3_Y[0];
+         int __inline_3_decomp_11;
+         __inline_3_decomp_11 = __inline_3_X[0] + __inline_3_Y[0];
+         x = __inline_3_decomp_11;
       }
    }
    {
@@ -105,133 +115,209 @@ int main() {
                int y;
                y = x + A[0];
                {
-                  int __inline_5_x;
-                  __inline_5_x = x;
-                  int __inline_5_y;
-                  __inline_5_y = y;
-                  int *__inline_5_X;
-                  __inline_5_X = C;
+                  int __inline_7_x;
+                  __inline_7_x = x;
+                  int __inline_7_y;
+                  __inline_7_y = y;
+                  int *__inline_7_X;
+                  __inline_7_X = C;
                   {
                      {
-                        int *__inline_5___inline_4_X;
-                        __inline_5___inline_4_X = __inline_5_X;
-                        int *__inline_5___inline_4_Y;
-                        __inline_5___inline_4_Y = __inline_5_X;
+                        int *__inline_7___inline_4_X;
+                        __inline_7___inline_4_X = __inline_7_X;
+                        int *__inline_7___inline_4_Y;
+                        __inline_7___inline_4_Y = __inline_7_X;
                         {
                            {
-                              int __inline_5___inline_4_i;
-                              __inline_5___inline_4_i = 0;
-                              int __inline_5___inline_4_decomp_1;
-                              __inline_5___inline_4_decomp_1 = __inline_5___inline_4_i < 100;
-                              while(__inline_5___inline_4_decomp_1) {
-                                 __inline_5___inline_4_X[__inline_5___inline_4_i] = __inline_5___inline_4_X[__inline_5___inline_4_i] * __inline_5___inline_4_Y[__inline_5___inline_4_i];
-                                 __inline_5___inline_4_i++;
-                                 __inline_5___inline_4_decomp_1 = __inline_5___inline_4_i < 100;
+                              int __inline_7___inline_4_i;
+                              __inline_7___inline_4_i = 0;
+                              int __inline_7___inline_4_decomp_1;
+                              __inline_7___inline_4_decomp_1 = __inline_7___inline_4_i < 100;
+                              while(__inline_7___inline_4_decomp_1) {
+                                 __inline_7___inline_4_X[__inline_7___inline_4_i] = __inline_7___inline_4_X[__inline_7___inline_4_i] * __inline_7___inline_4_Y[__inline_7___inline_4_i];
+                                 __inline_7___inline_4_i++;
+                                 __inline_7___inline_4_decomp_1 = __inline_7___inline_4_i < 100;
                               }
                            }
                            {
-                              int __inline_5___inline_4_i;
-                              __inline_5___inline_4_i = 0;
-                              int __inline_5___inline_4_decomp_2;
-                              __inline_5___inline_4_decomp_2 = __inline_5___inline_4_i < 100;
-                              while(__inline_5___inline_4_decomp_2) {
-                                 __inline_5___inline_4_Y[__inline_5___inline_4_i] = __inline_5___inline_4_X[__inline_5___inline_4_i] + __inline_5___inline_4_Y[__inline_5___inline_4_i];
+                              int __inline_7___inline_4_i;
+                              __inline_7___inline_4_i = 0;
+                              int __inline_7___inline_4_decomp_2;
+                              __inline_7___inline_4_decomp_2 = __inline_7___inline_4_i < 100;
+                              while(__inline_7___inline_4_decomp_2) {
+                                 __inline_7___inline_4_Y[__inline_7___inline_4_i] = __inline_7___inline_4_X[__inline_7___inline_4_i] + __inline_7___inline_4_Y[__inline_7___inline_4_i];
                                  {
-                                    int __inline_5___inline_4___inline_1_x;
-                                    __inline_5___inline_4___inline_1_x = __inline_5___inline_4_Y[__inline_5___inline_4_i];
+                                    int __inline_7___inline_4___inline_1_x;
+                                    __inline_7___inline_4___inline_1_x = __inline_7___inline_4_Y[__inline_7___inline_4_i];
                                     {
-                                       __inline_5___inline_4_Y[__inline_5___inline_4_i] = __inline_5___inline_4___inline_1_x * __inline_5___inline_4___inline_1_x * __inline_5___inline_4___inline_1_x;
+                                       int __inline_7___inline_4___inline_1_decomp_9;
+                                       __inline_7___inline_4___inline_1_decomp_9 = __inline_7___inline_4___inline_1_x * __inline_7___inline_4___inline_1_x;
+                                       int __inline_7___inline_4___inline_1_decomp_10;
+                                       __inline_7___inline_4___inline_1_decomp_10 = __inline_7___inline_4___inline_1_decomp_9 * __inline_7___inline_4___inline_1_x;
+                                       __inline_7___inline_4_Y[__inline_7___inline_4_i] = __inline_7___inline_4___inline_1_decomp_10;
                                     }
                                  }
-                                 __inline_5___inline_4_i++;
-                                 __inline_5___inline_4_decomp_2 = __inline_5___inline_4_i < 100;
+                                 __inline_7___inline_4_i++;
+                                 __inline_7___inline_4_decomp_2 = __inline_7___inline_4_i < 100;
                               }
                            }
                            {
-                              int __inline_5___inline_4_i;
-                              __inline_5___inline_4_i = 0;
-                              int __inline_5___inline_4_decomp_3;
-                              __inline_5___inline_4_decomp_3 = __inline_5___inline_4_i < 100;
-                              while(__inline_5___inline_4_decomp_3) {
-                                 __inline_5___inline_4_Y[__inline_5___inline_4_i] = __inline_5___inline_4_X[__inline_5___inline_4_i] * __inline_5___inline_4_Y[__inline_5___inline_4_i];
+                              int __inline_7___inline_4_i;
+                              __inline_7___inline_4_i = 0;
+                              int __inline_7___inline_4_decomp_3;
+                              __inline_7___inline_4_decomp_3 = __inline_7___inline_4_i < 100;
+                              while(__inline_7___inline_4_decomp_3) {
+                                 __inline_7___inline_4_Y[__inline_7___inline_4_i] = __inline_7___inline_4_X[__inline_7___inline_4_i] * __inline_7___inline_4_Y[__inline_7___inline_4_i];
                                  {
-                                    int __inline_5___inline_4___inline_2_x;
-                                    __inline_5___inline_4___inline_2_x = __inline_5___inline_4_Y[__inline_5___inline_4_i];
+                                    int __inline_7___inline_4___inline_2_x;
+                                    __inline_7___inline_4___inline_2_x = __inline_7___inline_4_Y[__inline_7___inline_4_i];
                                     {
-                                       __inline_5___inline_4_Y[__inline_5___inline_4_i] = __inline_5___inline_4___inline_2_x * __inline_5___inline_4___inline_2_x * __inline_5___inline_4___inline_2_x;
+                                       int __inline_7___inline_4___inline_2_decomp_9;
+                                       __inline_7___inline_4___inline_2_decomp_9 = __inline_7___inline_4___inline_2_x * __inline_7___inline_4___inline_2_x;
+                                       int __inline_7___inline_4___inline_2_decomp_10;
+                                       __inline_7___inline_4___inline_2_decomp_10 = __inline_7___inline_4___inline_2_decomp_9 * __inline_7___inline_4___inline_2_x;
+                                       __inline_7___inline_4_Y[__inline_7___inline_4_i] = __inline_7___inline_4___inline_2_decomp_10;
                                     }
                                  }
-                                 __inline_5___inline_4_i++;
-                                 __inline_5___inline_4_decomp_3 = __inline_5___inline_4_i < 100;
+                                 __inline_7___inline_4_i++;
+                                 __inline_7___inline_4_decomp_3 = __inline_7___inline_4_i < 100;
                               }
                            }
+                           int __inline_7___inline_4_decomp_11;
+                           __inline_7___inline_4_decomp_11 = __inline_7___inline_4_X[0] + __inline_7___inline_4_Y[0];
                         }
                      }
+                     int __inline_7_decomp_12;
+                     {
+                        int __inline_7___inline_5_x;
+                        __inline_7___inline_5_x = __inline_7_x;
+                        {
+                           int __inline_7___inline_5_decomp_9;
+                           __inline_7___inline_5_decomp_9 = __inline_7___inline_5_x * __inline_7___inline_5_x;
+                           int __inline_7___inline_5_decomp_10;
+                           __inline_7___inline_5_decomp_10 = __inline_7___inline_5_decomp_9 * __inline_7___inline_5_x;
+                           __inline_7_decomp_12 = __inline_7___inline_5_decomp_10;
+                        }
+                     }
+                     int __inline_7_decomp_13;
+                     {
+                        int __inline_7___inline_6_x;
+                        __inline_7___inline_6_x = __inline_7_y;
+                        {
+                           int __inline_7___inline_6_decomp_9;
+                           __inline_7___inline_6_decomp_9 = __inline_7___inline_6_x * __inline_7___inline_6_x;
+                           int __inline_7___inline_6_decomp_10;
+                           __inline_7___inline_6_decomp_10 = __inline_7___inline_6_decomp_9 * __inline_7___inline_6_x;
+                           __inline_7_decomp_13 = __inline_7___inline_6_decomp_10;
+                        }
+                     }
+                     int __inline_7_decomp_14;
+                     __inline_7_decomp_14 = __inline_7_decomp_12 + __inline_7_decomp_13;
+                     int __inline_7_decomp_15;
+                     __inline_7_decomp_15 = __inline_7_decomp_14 + __inline_7_X[6];
                   }
                }
                {
-                  int __inline_6_x;
-                  __inline_6_x = y;
-                  int __inline_6_y;
-                  __inline_6_y = x;
-                  int *__inline_6_X;
-                  __inline_6_X = C;
+                  int __inline_8_x;
+                  __inline_8_x = y;
+                  int __inline_8_y;
+                  __inline_8_y = x;
+                  int *__inline_8_X;
+                  __inline_8_X = C;
                   {
                      {
-                        int *__inline_6___inline_4_X;
-                        __inline_6___inline_4_X = __inline_6_X;
-                        int *__inline_6___inline_4_Y;
-                        __inline_6___inline_4_Y = __inline_6_X;
+                        int *__inline_8___inline_4_X;
+                        __inline_8___inline_4_X = __inline_8_X;
+                        int *__inline_8___inline_4_Y;
+                        __inline_8___inline_4_Y = __inline_8_X;
                         {
                            {
-                              int __inline_6___inline_4_i;
-                              __inline_6___inline_4_i = 0;
-                              int __inline_6___inline_4_decomp_1;
-                              __inline_6___inline_4_decomp_1 = __inline_6___inline_4_i < 100;
-                              while(__inline_6___inline_4_decomp_1) {
-                                 __inline_6___inline_4_X[__inline_6___inline_4_i] = __inline_6___inline_4_X[__inline_6___inline_4_i] * __inline_6___inline_4_Y[__inline_6___inline_4_i];
-                                 __inline_6___inline_4_i++;
-                                 __inline_6___inline_4_decomp_1 = __inline_6___inline_4_i < 100;
+                              int __inline_8___inline_4_i;
+                              __inline_8___inline_4_i = 0;
+                              int __inline_8___inline_4_decomp_1;
+                              __inline_8___inline_4_decomp_1 = __inline_8___inline_4_i < 100;
+                              while(__inline_8___inline_4_decomp_1) {
+                                 __inline_8___inline_4_X[__inline_8___inline_4_i] = __inline_8___inline_4_X[__inline_8___inline_4_i] * __inline_8___inline_4_Y[__inline_8___inline_4_i];
+                                 __inline_8___inline_4_i++;
+                                 __inline_8___inline_4_decomp_1 = __inline_8___inline_4_i < 100;
                               }
                            }
                            {
-                              int __inline_6___inline_4_i;
-                              __inline_6___inline_4_i = 0;
-                              int __inline_6___inline_4_decomp_2;
-                              __inline_6___inline_4_decomp_2 = __inline_6___inline_4_i < 100;
-                              while(__inline_6___inline_4_decomp_2) {
-                                 __inline_6___inline_4_Y[__inline_6___inline_4_i] = __inline_6___inline_4_X[__inline_6___inline_4_i] + __inline_6___inline_4_Y[__inline_6___inline_4_i];
+                              int __inline_8___inline_4_i;
+                              __inline_8___inline_4_i = 0;
+                              int __inline_8___inline_4_decomp_2;
+                              __inline_8___inline_4_decomp_2 = __inline_8___inline_4_i < 100;
+                              while(__inline_8___inline_4_decomp_2) {
+                                 __inline_8___inline_4_Y[__inline_8___inline_4_i] = __inline_8___inline_4_X[__inline_8___inline_4_i] + __inline_8___inline_4_Y[__inline_8___inline_4_i];
                                  {
-                                    int __inline_6___inline_4___inline_1_x;
-                                    __inline_6___inline_4___inline_1_x = __inline_6___inline_4_Y[__inline_6___inline_4_i];
+                                    int __inline_8___inline_4___inline_1_x;
+                                    __inline_8___inline_4___inline_1_x = __inline_8___inline_4_Y[__inline_8___inline_4_i];
                                     {
-                                       __inline_6___inline_4_Y[__inline_6___inline_4_i] = __inline_6___inline_4___inline_1_x * __inline_6___inline_4___inline_1_x * __inline_6___inline_4___inline_1_x;
+                                       int __inline_8___inline_4___inline_1_decomp_9;
+                                       __inline_8___inline_4___inline_1_decomp_9 = __inline_8___inline_4___inline_1_x * __inline_8___inline_4___inline_1_x;
+                                       int __inline_8___inline_4___inline_1_decomp_10;
+                                       __inline_8___inline_4___inline_1_decomp_10 = __inline_8___inline_4___inline_1_decomp_9 * __inline_8___inline_4___inline_1_x;
+                                       __inline_8___inline_4_Y[__inline_8___inline_4_i] = __inline_8___inline_4___inline_1_decomp_10;
                                     }
                                  }
-                                 __inline_6___inline_4_i++;
-                                 __inline_6___inline_4_decomp_2 = __inline_6___inline_4_i < 100;
+                                 __inline_8___inline_4_i++;
+                                 __inline_8___inline_4_decomp_2 = __inline_8___inline_4_i < 100;
                               }
                            }
                            {
-                              int __inline_6___inline_4_i;
-                              __inline_6___inline_4_i = 0;
-                              int __inline_6___inline_4_decomp_3;
-                              __inline_6___inline_4_decomp_3 = __inline_6___inline_4_i < 100;
-                              while(__inline_6___inline_4_decomp_3) {
-                                 __inline_6___inline_4_Y[__inline_6___inline_4_i] = __inline_6___inline_4_X[__inline_6___inline_4_i] * __inline_6___inline_4_Y[__inline_6___inline_4_i];
+                              int __inline_8___inline_4_i;
+                              __inline_8___inline_4_i = 0;
+                              int __inline_8___inline_4_decomp_3;
+                              __inline_8___inline_4_decomp_3 = __inline_8___inline_4_i < 100;
+                              while(__inline_8___inline_4_decomp_3) {
+                                 __inline_8___inline_4_Y[__inline_8___inline_4_i] = __inline_8___inline_4_X[__inline_8___inline_4_i] * __inline_8___inline_4_Y[__inline_8___inline_4_i];
                                  {
-                                    int __inline_6___inline_4___inline_2_x;
-                                    __inline_6___inline_4___inline_2_x = __inline_6___inline_4_Y[__inline_6___inline_4_i];
+                                    int __inline_8___inline_4___inline_2_x;
+                                    __inline_8___inline_4___inline_2_x = __inline_8___inline_4_Y[__inline_8___inline_4_i];
                                     {
-                                       __inline_6___inline_4_Y[__inline_6___inline_4_i] = __inline_6___inline_4___inline_2_x * __inline_6___inline_4___inline_2_x * __inline_6___inline_4___inline_2_x;
+                                       int __inline_8___inline_4___inline_2_decomp_9;
+                                       __inline_8___inline_4___inline_2_decomp_9 = __inline_8___inline_4___inline_2_x * __inline_8___inline_4___inline_2_x;
+                                       int __inline_8___inline_4___inline_2_decomp_10;
+                                       __inline_8___inline_4___inline_2_decomp_10 = __inline_8___inline_4___inline_2_decomp_9 * __inline_8___inline_4___inline_2_x;
+                                       __inline_8___inline_4_Y[__inline_8___inline_4_i] = __inline_8___inline_4___inline_2_decomp_10;
                                     }
                                  }
-                                 __inline_6___inline_4_i++;
-                                 __inline_6___inline_4_decomp_3 = __inline_6___inline_4_i < 100;
+                                 __inline_8___inline_4_i++;
+                                 __inline_8___inline_4_decomp_3 = __inline_8___inline_4_i < 100;
                               }
                            }
+                           int __inline_8___inline_4_decomp_11;
+                           __inline_8___inline_4_decomp_11 = __inline_8___inline_4_X[0] + __inline_8___inline_4_Y[0];
                         }
                      }
+                     int __inline_8_decomp_12;
+                     {
+                        int __inline_8___inline_5_x;
+                        __inline_8___inline_5_x = __inline_8_x;
+                        {
+                           int __inline_8___inline_5_decomp_9;
+                           __inline_8___inline_5_decomp_9 = __inline_8___inline_5_x * __inline_8___inline_5_x;
+                           int __inline_8___inline_5_decomp_10;
+                           __inline_8___inline_5_decomp_10 = __inline_8___inline_5_decomp_9 * __inline_8___inline_5_x;
+                           __inline_8_decomp_12 = __inline_8___inline_5_decomp_10;
+                        }
+                     }
+                     int __inline_8_decomp_13;
+                     {
+                        int __inline_8___inline_6_x;
+                        __inline_8___inline_6_x = __inline_8_y;
+                        {
+                           int __inline_8___inline_6_decomp_9;
+                           __inline_8___inline_6_decomp_9 = __inline_8___inline_6_x * __inline_8___inline_6_x;
+                           int __inline_8___inline_6_decomp_10;
+                           __inline_8___inline_6_decomp_10 = __inline_8___inline_6_decomp_9 * __inline_8___inline_6_x;
+                           __inline_8_decomp_13 = __inline_8___inline_6_decomp_10;
+                        }
+                     }
+                     int __inline_8_decomp_14;
+                     __inline_8_decomp_14 = __inline_8_decomp_12 + __inline_8_decomp_13;
+                     int __inline_8_decomp_15;
+                     __inline_8_decomp_15 = __inline_8_decomp_14 + __inline_8_X[6];
                   }
                }
                j++;
@@ -310,4 +396,20 @@ int inlineTest2() {
    a = b;
    
    return a;
+}
+
+void arrayParam() {
+   int a[32];
+   int b;
+   {
+      int __inline_2_decomp_17;
+      {
+         int __inline_2___inline_1_decomp_16;
+         {
+            __inline_2___inline_1_decomp_16 = a[0];
+         }
+         __inline_2_decomp_17 = __inline_2___inline_1_decomp_16;
+      }
+      b = __inline_2_decomp_17;
+   }
 }

--- a/ClavaWeaver/resources/clava/test/api/c/src/inliner.c
+++ b/ClavaWeaver/resources/clava/test/api/c/src/inliner.c
@@ -84,3 +84,26 @@ int inlineTest2() {
 
 	return a;
 }
+
+
+
+int arrayParamL3(int key[32]) {
+	return key[0];
+}
+
+int arrayParamL2(int key[32]) {
+	return arrayParamL3(key);
+}
+
+int arrayParamL1(int key[32]) {
+	return arrayParamL2(key);
+}
+
+
+void arrayParam() {
+    int a[32];
+    int b;
+    
+    b = arrayParamL1(a);
+    
+}


### PR DESCRIPTION
Inliner was not supporting when the function to inline had array parameters. Also, return statements were not being decomposed, which would prevent inlining functions that only had a return statement (which usually are prime candidates for inlining).