### PR TITLE
Convert switch to if-else conditions

### DIFF
--- a/ClavaLaraApi/src-java/pt/up/fe/specs/clava/weaver/LaraApiResource.java
+++ b/ClavaLaraApi/src-java/pt/up/fe/specs/clava/weaver/LaraApiResource.java
@@ -147,6 +147,7 @@ public enum LaraApiResource implements LaraResourceProvider {
     DECOMPOSE_VAR_DECLARATIONS("pass/DecomposeVarDeclarations.js"),
     LOCAL_STATIC_TO_GLOBAL("pass/LocalStaticToGlobal.js"),
     SINGLE_RETURN_FUNCTION("pass/SingleReturnFunction.js"),
+    SWITCH_TO_IF("pass/SwitchToIf.js"),
     PASS_SIMPLIFY_LOOPS("pass/SimplifyLoops.js"),
     PASS_SIMPLIFY_RETURN("pass/SimplifyReturnStmts.js"),
     PASS_SIMPLIFY_SELECTION_STMTS("pass/SimplifySelectionStmts.js"),

--- a/ClavaLaraApi/src-java/pt/up/fe/specs/clava/weaver/LaraApiResource.java
+++ b/ClavaLaraApi/src-java/pt/up/fe/specs/clava/weaver/LaraApiResource.java
@@ -147,10 +147,10 @@ public enum LaraApiResource implements LaraResourceProvider {
     DECOMPOSE_VAR_DECLARATIONS("pass/DecomposeVarDeclarations.js"),
     LOCAL_STATIC_TO_GLOBAL("pass/LocalStaticToGlobal.js"),
     SINGLE_RETURN_FUNCTION("pass/SingleReturnFunction.js"),
-    SWITCH_TO_IF("pass/SwitchToIf.js"),
     PASS_SIMPLIFY_LOOPS("pass/SimplifyLoops.js"),
     PASS_SIMPLIFY_RETURN("pass/SimplifyReturnStmts.js"),
     PASS_SIMPLIFY_SELECTION_STMTS("pass/SimplifySelectionStmts.js"),
+    TRANSFORM_SWITCH_TO_IF("pass/TransformSwitchToIf.js"),
 
     // Stats
     OPS_BLOCK("stats/OpsBlock.lara"),

--- a/ClavaLaraApi/src-lara-clava/clava/clava/pass/SwitchToIf.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/pass/SwitchToIf.js
@@ -1,0 +1,74 @@
+laraImport("lara.pass.Pass");
+laraImport("weaver.Query");
+laraImport("clava.ClavaJoinPoints");
+laraImport("lara.Strings");
+
+class SwitchToIf extends SimplePass {
+    /**
+     * @return {string} Name of the pass
+     * @override
+     */
+    get name() {
+        return "SwitchToIf";
+    }
+
+    matchJoinpoint($jp) {
+        return $jp.instanceOf("switch");
+    }
+
+    transformJoinpoint($jp) {
+        const $switchCondition = $jp.condition;
+        const $switchEndLabel = ClavaJoinPoints.labelDecl("end_switch_" + $jp.astId);
+        const $switchEndGoTo = ClavaJoinPoints.gotoStmt($switchEndLabel);
+        $jp.insertAfter($switchEndLabel);
+
+        // TODO: handle switch with only one case stmt that is the default
+        // TODO: handle intermediate default case
+        // TODO: handle case stmts with more that one value
+        // Create 'if' statement for each case
+        let caseLabels = new Map();
+        let caseIfs = new Array();
+        for (const $case of $jp.cases) {
+            const labelName = $case.isDefault ? "case_" + $case.astId : "case_" + $case.astId;
+            const $labelDecl = ClavaJoinPoints.labelDecl(labelName);
+            const $goto = ClavaJoinPoints.gotoStmt($labelDecl);
+            caseLabels.set($case.astId, labelDecl);
+            
+            if ($case.isDefault) {
+                caseIfs.push($goto);
+                continue;
+            }
+
+            const $type = ClavaJoinPoints.type("boolean");
+            const $binOp = ClavaJoinPoints.binaryOp("==", $switchCondition, $case.values[0], $type);
+            const $ifStmt = ClavaJoinPoints.ifStmt($binOp, $goto);
+
+            caseIfs.push($ifStmt);
+        }
+
+        $jp.insertBefore(caseIfs[0]);
+        for (let i = 0; i < caseIfs.length - 1; i++) {
+            const $ifStmt = caseIfs[i];
+            const $nextIfStmt = caseIfs[i + 1];
+            $ifStmt.setElse($nextIfStmt);            
+        }
+
+        for (const $case of $jp.cases) { 
+            const $caseLabel = caseLabels.get($case.astId);
+            $jp.insertBefore($caseLabel);
+
+            for (const $inst of $case.instructions) {
+                $jp.insertBefore($inst);
+
+                const $breakStmts = Query.searchFromInclusive($inst, "break");
+                for (const $break of $breakStmts) {
+                    if($break.enclosingStmt.instanceOf("switch"))
+                        $break.replaceWith($switchEndGoTo);
+                }
+            }
+        }
+
+        $jp.detach();
+        //return new PassResult(this, $firstDeclStmt);
+    }
+}

--- a/ClavaLaraApi/src-lara-clava/clava/clava/pass/SwitchToIf.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/pass/SwitchToIf.js
@@ -19,10 +19,9 @@ class SwitchToIf extends SimplePass {
     transformJoinpoint($jp) {
         const $switchCondition = $jp.condition;
         const $switchEndLabel = ClavaJoinPoints.labelDecl("end_switch_" + $jp.astId);
+        const $switchEndLabelStmt = ClavaJoinPoints.labelStmt($switchEndLabel);
         const $switchEndGoTo = ClavaJoinPoints.gotoStmt($switchEndLabel);
-        $jp.insertAfter($switchEndLabel);
 
-        // TODO: handle case stmts with more that one value
         // Create 'if' statement for each case
         let caseLabels = new Map();
         let switchConditions = new Array();
@@ -30,50 +29,64 @@ class SwitchToIf extends SimplePass {
             const labelName = $case.isDefault ? "case_" + $case.astId : "case_" + $case.astId;
             const $labelDecl = ClavaJoinPoints.labelDecl(labelName);
             const $goto = ClavaJoinPoints.gotoStmt($labelDecl);
-            caseLabels.set($case.astId, labelDecl);
+
+            const $labelStmt = ClavaJoinPoints.labelStmt($labelDecl);
+            caseLabels.set($case.astId, $labelStmt);
             
             if ($case.isDefault) {
                 switchConditions.push($goto);
                 continue;
             }
 
-            const $type = ClavaJoinPoints.type("boolean");
-            const $binOp = ClavaJoinPoints.binaryOp("==", $switchCondition, $case.values[0], $type);
-            const $ifStmt = ClavaJoinPoints.ifStmt($binOp, $goto);
+            let $ifCondition;
+            if($case.values.length == 1)
+                $ifCondition = ClavaJoinPoints.binaryOp("==", $switchCondition, $case.values[0], "boolean");
+            else {
+                const $binOpGE = ClavaJoinPoints.binaryOp(">=", $switchCondition, $case.values[0], "boolean");
+                const $binOpLE = ClavaJoinPoints.binaryOp("<=", $switchCondition, $case.values[1], "boolean");
+                $ifCondition = ClavaJoinPoints.binaryOp("&&", $binOpGE, $binOpLE, "boolean"); 
+            }
+            const $ifStmt = ClavaJoinPoints.ifStmt($ifCondition, $goto);
 
             switchConditions.push($ifStmt);
         }
 
         $jp.insertBefore(switchConditions[0]);
+
+        // Move intermediate default to the end
         this.#moveDefaultToEnd(switchConditions);
+
+        // Connect the switch conditions
         for (let i = 0; i < switchConditions.length - 1; i++) {
             const $ifStmt = switchConditions[i];
             const $nextIfStmt = switchConditions[i + 1];
             $ifStmt.setElse($nextIfStmt);            
         }
 
+        // Replace break statements with goto statements
+        const $breakStmts = Query.searchFromInclusive($jp, "break", {enclosingStmt: enclosingStmt => enclosingStmt.instanceOf("switch")});
+        for (const $break of $breakStmts)
+            $break.replaceWith($switchEndGoTo);
+
+        // Insert label and instructions of each case statement
         for (const $case of $jp.cases) { 
             const $caseLabel = caseLabels.get($case.astId);
             $jp.insertBefore($caseLabel);
 
-            for (const $inst of $case.instructions) {
+            for (const $inst of $case.instructions)
                 $jp.insertBefore($inst);
-
-                const $breakStmts = Query.searchFromInclusive($inst, "break");
-                for (const $break of $breakStmts) {
-                    if($break.enclosingStmt.instanceOf("switch"))
-                        $break.replaceWith($switchEndGoTo);
-                }
-            }
         }
 
+        $jp.insertAfter($switchEndLabelStmt);
+        if ($switchEndLabelStmt.isLast)
+            $switchEndLabelStmt.insertAfter(ClavaJoinPoints.emptyStmt());
         $jp.detach();
-        //return new PassResult(this, $firstDeclStmt);
+        return new PassResult(this, switchConditions[0]);
     }
 
     #moveDefaultToEnd(switchConditions) {
         const index = switchConditions.findIndex($condition => $condition.instanceOf("gotoStmt"));
         if (index !== -1)
-            switchConditions.push(array.splice(index, 1)[0]);
+            switchConditions.push(switchConditions.splice(index, 1)[0]);
     }
 }

--- a/ClavaLaraApi/src-lara-clava/clava/clava/pass/TransformSwitchToIf.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/pass/TransformSwitchToIf.js
@@ -21,6 +21,8 @@ laraImport("lara.pass.results.PassResult");
  *	   case 2:
  *	       a = 20;
  *	       break;
+ *     case 3 ... 7:
+ *         a = 30;
  *	}
  * ```
  * 
@@ -33,22 +35,27 @@ laraImport("lara.pass.results.PassResult");
  *      goto case_1;
  *  else if (num == 2) 
  *      goto case_2;
- *  else goto case_default;
+ *  else if (num >= 3 && num <= 7) 
+ *       goto case_3_7;
+ *  else 
+ *       goto case_default;
  * 
  *  case_1:
  *      a = 10;
  *  case_default:
- *      a = 30;
+ *      a = 80;
  *      goto switch_exit;
  *  case_2:
  *      a = 20;
  *      goto switch_exit;
+ *  case_3_7:
+ *      a = 30;
  * 
  *  switch_exit:
  *  ;
  * ```
  */
-class SwitchToIf extends SimplePass {
+class TransformSwitchToIf extends SimplePass {
     /**
      * Maps each case statement id to the corresponding label statement
      */
@@ -64,7 +71,7 @@ class SwitchToIf extends SimplePass {
      * @override
      */
     get name() {
-        return "SwitchToIf";
+        return "TransformSwitchToIf";
     }
 
     matchJoinpoint($jp) {
@@ -77,7 +84,7 @@ class SwitchToIf extends SimplePass {
      * @param {JoinPoint} $jp Join point to transform
      */
     transformJoinpoint($jp) {
-        const $switchExitLabel = ClavaJoinPoints.labelDecl("switch_exit" + $jp.astId);
+        const $switchExitLabel = ClavaJoinPoints.labelDecl("switch_exit_" + $jp.astId);
         const $switchExitLabelStmt = ClavaJoinPoints.labelStmt($switchExitLabel);
         const $switchExitGoTo = ClavaJoinPoints.gotoStmt($switchExitLabel);
 
@@ -100,7 +107,7 @@ class SwitchToIf extends SimplePass {
     }
 
     /**
-     * Creates if and label statements for each case in the provided switch statement and adds them to the private fields "caseLabels" and "caseIfStmts".
+     * Creates if and label statements for each case in the provided switch statement and adds them to the private fields "caseIfStmts" and "caseLabels".
      * @param {joinpoint} $jp the switch statement
      */
     #computeIfAndLabels($jp) {

--- a/ClavaLaraApi/src-lara-clava/clava/clava/pass/TransformSwitchToIf.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/pass/TransformSwitchToIf.js
@@ -94,7 +94,11 @@ class TransformSwitchToIf extends SimplePass {
             $switchExitLabelStmt.insertAfter(ClavaJoinPoints.emptyStmt());
 
         this.#computeIfAndLabels($jp);
-        this.#moveDefaultToEnd();
+        
+        if ($jp.hasDefaultCase)
+            this.#moveDefaultToEnd();
+        else
+            this.#caseIfStmts.push($switchExitGoTo);
 
         $jp.insertBefore(this.#caseIfStmts[0]);
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ If you have used Clava, please consider filling the [Clava User Experience Feedb
 
 Clava also supports LARA files (`.lara`), but the LARA DSL is now considered legacy, please use JavaScript instead. 
 
+
 # Compatibility
 
 Currently Clava requires Java 11.


### PR DESCRIPTION
Added the `TransformSwitchToIf` class which converts a switch statement like this:
```cpp
int num = 1, a;

switch (num) {
    case 1:
        a = 10;
    default:
        a = 80;
        break;
    case 2:
        a = 20;
        break;
    case 3 ... 7:
        a = 30;
}
```

Into this:
```cpp
int num = 1, a;

if (num == 1) 
    goto case_1;
else if (num == 2) 
    goto case_2;
else if (num >= 3 && num <= 7) 
    goto case_3_7;
else 
    goto case_default;

case_1:
    a = 10;
case_default:
    a = 80;
    goto switch_exit;
case_2:
    a = 20;
    goto switch_exit;
case_3_7:
    a = 30;
    
switch_exit:
;
```
<br>

**Note**:
- To avoid adding duplicate labels to the AST when dealing with multiple switch statements, the label name of the switch exit and case statement actually contains its astId (e.g: `switch_exit_0x14fb5a5b0b8`, `case_0x14fb5a5b120`)
- Since the switch statement of the given example is the last child of its parent node, an empty statement was inserted after the switch_exit label:

```c
// ...

switch_exit:
;   // the empty statement
```