### PR TITLE
CFG improvements: goto and label connection and constructor update

### DIFF
--- a/ClavaLaraApi/src-java/pt/up/fe/specs/clava/weaver/LaraApiResource.java
+++ b/ClavaLaraApi/src-java/pt/up/fe/specs/clava/weaver/LaraApiResource.java
@@ -106,6 +106,7 @@ public enum LaraApiResource implements LaraResourceProvider {
     CFG_HEADER_DATA("graphs/cfg/nodedata/HeaderData.js"),
     CFG_IF_DATA("graphs/cfg/nodedata/IfData.js"),
     CFG_INST_LIST_NODE_DATA("graphs/cfg/nodedata/InstListNodeData.js"),
+    CFG_LABEL_DATA("graphs/cfg/nodedata/LabelData.js"),
     CFG_LOOP_DATA("graphs/cfg/nodedata/LoopData.js"),
     CFG_SCOPE_NODE_DATA("graphs/cfg/nodedata/ScopeNodeData.js"),
     CFG_SWITCH_DATA("graphs/cfg/nodedata/SwitchData.js"),

--- a/ClavaLaraApi/src-java/pt/up/fe/specs/clava/weaver/LaraApiResource.java
+++ b/ClavaLaraApi/src-java/pt/up/fe/specs/clava/weaver/LaraApiResource.java
@@ -102,6 +102,7 @@ public enum LaraApiResource implements LaraResourceProvider {
 
     CFG_CASE_DATA("graphs/cfg/nodedata/CaseData.js"),
     CFG_DATA_FACTORY("graphs/cfg/nodedata/DataFactory.js"),
+    CFG_GOTO_DATA("graphs/cfg/nodedata/GotoData.js"),
     CFG_HEADER_DATA("graphs/cfg/nodedata/HeaderData.js"),
     CFG_IF_DATA("graphs/cfg/nodedata/IfData.js"),
     CFG_INST_LIST_NODE_DATA("graphs/cfg/nodedata/InstListNodeData.js"),

--- a/ClavaLaraApi/src-lara-clava/clava/clava/graphs/ControlFlowGraph.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/graphs/ControlFlowGraph.js
@@ -25,8 +25,20 @@ class ControlFlowGraph extends Graph {
     this.#endNode = endNode;
   }
 
-  static build($jp, deterministicIds = false, splitInstList = false) {
-    const builderResult = new CfgBuilder($jp, deterministicIds, splitInstList).build();
+  /**
+   * Builds the control flow graph
+   * 
+   * @param {joinpoint} $jp
+   * @param {boolean} [deterministicIds = false] If true, uses deterministic ids for the graph ids (e.g. id_0, id_1...). Otherwise, uses $jp.astId whenever possible
+   * @param {Object}  [options = {}] An object containing configuration options for the cfg
+   * @param {boolean} [options.splitInstList = false] If true, statements of each instruction list must be split
+   * @param {boolean} [options.removeGotoNodes = false] If true, the nodes that correspond to goto statements will be excluded from the resulting graph
+   * @param {boolean} [options.removeLabelNodes = false] If true, the nodes that correspond to label statements will be excluded from the resulting graph
+   * 
+   * @returns {ControlFlowGraph} a new instance of the ControlFlowGraph class
+  */
+  static build($jp, deterministicIds = false, options = {}) {
+    const builderResult = new CfgBuilder($jp, deterministicIds, options).build();
     return new ControlFlowGraph(...builderResult);
   }
 

--- a/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/CfgBuilder.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/CfgBuilder.js
@@ -436,6 +436,15 @@ class CfgBuilder {
     this.#addEdge(node, afterNode, CfgEdgeType.UNCONDITIONAL);
   }
 
+  /**
+   * @param {Cytoscape.node} node node whose type is "LABEL"
+   */
+  #connectLabelNode(node) {
+    const $labelStmt = node.data().nodeStmt;
+
+    const afterNode = this.#nextNodes.nextExecutedNode($labelStmt);
+    this.#addEdge(node, afterNode, CfgEdgeType.UNCONDITIONAL);
+  }
 
   /**
    * Connects a node associated with a statement that is an instance of a "return" statement.
@@ -525,6 +534,9 @@ class CfgBuilder {
           break;
         case CfgNodeType.GOTO:
           this.#connectGotoNode(node);
+          break;
+        case CfgNodeType.LABEL:
+          this.#connectLabelNode(node);
           break;
         case CfgNodeType.RETURN:
           this.#connectReturnNode(node);

--- a/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/CfgBuilder.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/CfgBuilder.js
@@ -88,9 +88,6 @@ class CfgBuilder {
   constructor($jp, deterministicIds = false, options = {}) {
     this.#jp = $jp;
     this.#deterministicIds = deterministicIds;
-    println("splitInst: " + options.splitInstList );
-    println ("hideLabelNodes: " + options.removeLabelNodes);
-    println ("hideGotoNodes: " + options.removeGotoNodes );
     this.#splitInstList = options.splitInstList || false;
     this.#removeGotoNodes = options.removeGotoNodes || false;
     this.#removeLabelNodes = options.removeLabelNodes || false;
@@ -296,18 +293,9 @@ class CfgBuilder {
    */
   #connectBreakNode(node) {
     const $breakStmt = node.data().nodeStmt;
-    const $loop = $breakStmt.ancestor("loop");
-    const $switch = $breakStmt.ancestor("switch");
-    const loopDepth = $loop !== undefined ? $loop.depth : -1;
-    const switchDepth = $switch !== undefined ? $switch.depth : -1;
-    let afterNode = undefined;
+    const $enclosingStmt = $breakStmt.enclosingStmt;
 
-    if (loopDepth > switchDepth)
-      // Statement is used to terminate a loop
-      afterNode = this.#nextNodes.nextExecutedNode($loop);
-    // Statement is used to exit a switch block
-    else afterNode = this.#nextNodes.nextExecutedNode($switch);
-
+    const afterNode = this.#nextNodes.nextExecutedNode($enclosingStmt);
     this.#addEdge(node, afterNode, CfgEdgeType.UNCONDITIONAL);
   }
 

--- a/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/CfgBuilder.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/CfgBuilder.js
@@ -425,6 +425,19 @@ class CfgBuilder {
   }
 
   /**
+   * @param {Cytoscape.node} node node whose type is "GOTO"
+   */
+  #connectGotoNode(node) {
+    const $gotoStmt = node.data().nodeStmt;
+    const labelName = $gotoStmt.label.name;
+    const $labelStmt = Query.searchFromInclusive(this.#jp, "labelStmt", {decl: decl => decl.name == labelName}).first();
+
+    const afterNode = this.#nodes.get($labelStmt.astId);
+    this.#addEdge(node, afterNode, CfgEdgeType.UNCONDITIONAL);
+  }
+
+
+  /**
    * Connects a node associated with a statement that is an instance of a "return" statement.
    * @param {Cytoscape.node} node node whose type is "RETURN"
    */
@@ -509,6 +522,9 @@ class CfgBuilder {
           break;
         case CfgNodeType.INST_LIST:
           this.#connectInstListNode(node);
+          break;
+        case CfgNodeType.GOTO:
+          this.#connectGotoNode(node);
           break;
         case CfgNodeType.RETURN:
           this.#connectReturnNode(node);

--- a/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/CfgNodeType.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/CfgNodeType.js
@@ -18,8 +18,9 @@ class CfgNodeType {
   static CONTINUE = new CfgNodeType("CONTINUE");
   static SWITCH = new CfgNodeType("SWITCH");
   static CASE = new CfgNodeType("CASE");
-  static RETURN = new CfgNodeType("RETURN");
   static GOTO = new CfgNodeType("GOTO");
+  static LABEL = new CfgNodeType("LABEL");
+  static RETURN = new CfgNodeType("RETURN");
   // To add: WHILE, DOWHILE?
 
   //static SCOPE_DATA = new CfgNodeType("SCOPE_DATA")

--- a/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/CfgNodeType.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/CfgNodeType.js
@@ -19,6 +19,7 @@ class CfgNodeType {
   static SWITCH = new CfgNodeType("SWITCH");
   static CASE = new CfgNodeType("CASE");
   static RETURN = new CfgNodeType("RETURN");
+  static GOTO = new CfgNodeType("GOTO");
   // To add: WHILE, DOWHILE?
 
   //static SCOPE_DATA = new CfgNodeType("SCOPE_DATA")

--- a/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/CfgUtils.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/CfgUtils.js
@@ -42,9 +42,14 @@ class CfgUtils {
       return CfgNodeType.SWITCH;
     }
 
-    //Case stmt
+    // Case stmt
     if ($stmt.instanceOf("case")) {
       return CfgNodeType.CASE;
+    }
+
+    // Goto stmt
+    if ($stmt.instanceOf("gotoStmt")) {
+      return CfgNodeType.GOTO;
     }
 
     // Return stmt

--- a/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/CfgUtils.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/CfgUtils.js
@@ -52,6 +52,11 @@ class CfgUtils {
       return CfgNodeType.GOTO;
     }
 
+    // Label stmt
+    if ($stmt.instanceOf("labelStmt")) {
+      return CfgNodeType.LABEL;
+    }
+
     // Return stmt
     if ($stmt.instanceOf("returnStmt")) {
       return CfgNodeType.RETURN;

--- a/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/nodedata/CaseData.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/nodedata/CaseData.js
@@ -16,9 +16,7 @@ class CaseData extends CfgNodeData {
   }
 
   toString() {
-    if (this.case.isDefault)
-      return "default";
-    return "case " + this.case.values.map(value => value.code).join(" || ");
+    return this.case.code;
   }
 
   isBranch() {

--- a/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/nodedata/DataFactory.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/nodedata/DataFactory.js
@@ -7,6 +7,7 @@ laraImport("clava.graphs.cfg.nodedata.HeaderData");
 laraImport("clava.graphs.cfg.nodedata.IfData");
 laraImport("clava.graphs.cfg.nodedata.SwitchData");
 laraImport("clava.graphs.cfg.nodedata.CaseData");
+laraImport("clava.graphs.cfg.nodedata.GotoData");
 laraImport("clava.graphs.cfg.nodedata.ReturnData");
 
 class DataFactory {
@@ -38,6 +39,8 @@ class DataFactory {
         return new SwitchData($stmt, id);
       case CfgNodeType.CASE:
         return new CaseData($stmt, id);
+      case CfgNodeType.GOTO:
+        return new GotoData($stmt, id);
       case CfgNodeType.RETURN:
         return new ReturnData($stmt, id);
       default:

--- a/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/nodedata/DataFactory.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/nodedata/DataFactory.js
@@ -8,6 +8,7 @@ laraImport("clava.graphs.cfg.nodedata.IfData");
 laraImport("clava.graphs.cfg.nodedata.SwitchData");
 laraImport("clava.graphs.cfg.nodedata.CaseData");
 laraImport("clava.graphs.cfg.nodedata.GotoData");
+laraImport("clava.graphs.cfg.nodedata.LabelData");
 laraImport("clava.graphs.cfg.nodedata.ReturnData");
 
 class DataFactory {
@@ -41,6 +42,8 @@ class DataFactory {
         return new CaseData($stmt, id);
       case CfgNodeType.GOTO:
         return new GotoData($stmt, id);
+      case CfgNodeType.LABEL:
+        return new LabelData($stmt, id);
       case CfgNodeType.RETURN:
         return new ReturnData($stmt, id);
       default:

--- a/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/nodedata/GotoData.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/nodedata/GotoData.js
@@ -1,0 +1,17 @@
+laraImport("clava.graphs.cfg.CfgNodeData");
+laraImport("clava.graphs.cfg.CfgNodeType");
+
+class GotoData extends CfgNodeData {
+  //#stmt
+
+  constructor($stmt, id) {
+    super(CfgNodeType.GOTO, $stmt, id);
+
+    //this.#stmt = $stmt
+  }
+
+  toString() {
+    return this.nodeStmt.code;
+  }
+
+}

--- a/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/nodedata/LabelData.js
+++ b/ClavaLaraApi/src-lara-clava/clava/clava/graphs/cfg/nodedata/LabelData.js
@@ -1,0 +1,17 @@
+laraImport("clava.graphs.cfg.CfgNodeData");
+laraImport("clava.graphs.cfg.CfgNodeType");
+
+class LabelData extends CfgNodeData {
+  //#stmt
+
+  constructor($stmt, id) {
+    super(CfgNodeType.LABEL, $stmt, id);
+
+    //this.#stmt = $stmt
+  }
+
+  toString() {
+    return this.nodeStmt.code;
+  }
+
+}


### PR DESCRIPTION
This pull request introduces further improvements to the control flow graph (CFG):
- updated node connection to handle both goto and label statements
- refactored the connection of break nodes using the new attribute `$break.enclosingStmt`
- updated the constructors of both **CfgBuilder** and **ControlFlowGraph** classes to accept the cfg configuration options as an argument. This is an optional argument which can contain the following properties:
    - splitInstList
    - removeGotoNodes
    - removeLabelNodes