### PR TITLE
Feature/origin node

### DIFF
--- a/Clava-JS/src-api/Joinpoints.ts
+++ b/Clava-JS/src-api/Joinpoints.ts
@@ -182,6 +182,10 @@ export class Joinpoint extends LaraJoinPoint {
    */
   get numChildren(): number { return wrapJoinPoint(this._javaObject.getNumChildren()) }
   /**
+   * If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin
+   */
+  get originNode(): Joinpoint { return wrapJoinPoint(this._javaObject.getOriginNode()) }
+  /**
    * Returns the parent node in the AST, or undefined if it is the root node
    */
   get parent(): Joinpoint { return wrapJoinPoint(this._javaObject.getParent()) }

--- a/ClavaAst/src/pt/up/fe/specs/clava/ClavaNode.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ClavaNode.java
@@ -1515,4 +1515,39 @@ public abstract class ClavaNode extends ATreeNode<ClavaNode>
         return Optional.of(siblings.get(leftIndex));
     }
 
+    /**
+     * Sets the key INSERTION_POINT if conditions apply.<br>
+     * <br>
+     * Only sets insertion point if:<br>
+     * - There are at least two trees in the AST stack (i.e., create with pushAst())
+     * - The current node has an invalid location.
+     * @param target
+     */
+    public void setInsertionPoint(ClavaNode target) {
+        var previousApp = get(CONTEXT).getApp(1).orElse(null);
+
+        // Not setting insertion point
+        if(previousApp == null) {
+            return;
+        }
+        
+        // Find target node in previous app is target has valid location
+        var newTarget = target;
+        if(target.getLocation().isValid()) {
+            newTarget = previousApp.find(target).orElse(null);
+
+            /*
+            if(newTarget == null) {
+                System.out.println("Could not find corresponding node");
+            } else {
+                System.out.println("Found node in previous app. Are they the same instance? " + (newTarget == target));
+            }
+             */
+        }
+
+        var lambdaTarget = newTarget != null ? newTarget : target;
+        getDescendantsAndSelfStream()
+                //.filter(node -> !node.get(ClavaNode.LOCATION).isValid())
+                .forEach(node -> node.set(ClavaNode.INSERTION_POINT, Optional.of(lambdaTarget)));
+    }
 }

--- a/ClavaAst/src/pt/up/fe/specs/clava/ClavaNode.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ClavaNode.java
@@ -1524,24 +1524,22 @@ public abstract class ClavaNode extends ATreeNode<ClavaNode>
      */
     public void setOrigin(ClavaNode target) {
 
-        // No need to find previous app, when copying, automatically sets the origin
-/*
-        var previousApp = get(CONTEXT).getApp(1).orElse(null);
+        // If target node does not have an origin, it becomes the origin
+        // Otherwise, use the origin of the target
 
-        // Not setting insertion point
-        if(previousApp == null) {
-            return;
-        }
+        var origin = target.hasValue(ORIGIN) ? target.get(ORIGIN) : target;
 
-        // Find target node in previous app is target has valid location
-        var newTarget = target;
-        if(target.getLocation().isValid()) {
-            newTarget = previousApp.find(target).orElse(null);
-
-        }
-*/
         getDescendantsAndSelfStream()
-                //.filter(node -> !node.get(ClavaNode.LOCATION).isValid())
-                .forEach(node -> node.set(ClavaNode.ORIGIN, target));
+                .forEach(node -> node.set(ClavaNode.ORIGIN, origin));
     }
+
+    /**
+     *
+     * @return the node set on the key ORIGIN, or itself if no origin is set
+     */
+    public ClavaNode getOrigin() {
+        return hasValue(ClavaNode.ORIGIN) ? get(ClavaNode.ORIGIN) : this;
+    }
+
+
 }

--- a/ClavaAst/src/pt/up/fe/specs/clava/ClavaNode.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ClavaNode.java
@@ -118,6 +118,11 @@ public abstract class ClavaNode extends ATreeNode<ClavaNode>
 
     public final static DataKey<String> PREVIOUS_ID = KeyFactory.string("previousId");
 
+    /**
+     * If this node was not originally from the AST, contains the node that was used as an insertion point.
+     */
+    public final static DataKey<Optional<ClavaNode>> INSERTION_POINT = KeyFactory.optional("insertionPoint");
+
     /// DATAKEYS END
 
     public static String toTree(Collection<? extends ClavaNode> nodes) {

--- a/ClavaAst/src/pt/up/fe/specs/clava/ClavaNode.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ClavaNode.java
@@ -121,7 +121,7 @@ public abstract class ClavaNode extends ATreeNode<ClavaNode>
     /**
      * If this node was not originally from the AST, contains the node that was used as an insertion point.
      */
-    public final static DataKey<Optional<ClavaNode>> INSERTION_POINT = KeyFactory.optional("insertionPoint");
+    public final static DataKey<Optional<ClavaNode>> ORIGIN = KeyFactory.optional("insertionPoint");
 
     /// DATAKEYS END
 
@@ -344,6 +344,9 @@ public abstract class ClavaNode extends ATreeNode<ClavaNode>
         // the method version without arguments
         boolean overridesCopyPrivate = isCopyPrivateOverriden();
         ClavaNode newToken = overridesCopyPrivate ? copyPrivate() : copyPrivate(keepId);
+
+        // Set origin
+        newToken.set(ORIGIN, Optional.of(this));
 
         // Check new token does not have children
         if (newToken.getNumChildren() != 0) {
@@ -1516,38 +1519,29 @@ public abstract class ClavaNode extends ATreeNode<ClavaNode>
     }
 
     /**
-     * Sets the key INSERTION_POINT if conditions apply.<br>
-     * <br>
-     * Only sets insertion point if:<br>
-     * - There are at least two trees in the AST stack (i.e., create with pushAst())
-     * - The current node has an invalid location.
+     * Sets the key ORIGIN on this node and its descendents.
      * @param target
      */
-    public void setInsertionPoint(ClavaNode target) {
+    public void setOrigin(ClavaNode target) {
+
+        // No need to find previous app, when copying, automatically sets the origin
+/*
         var previousApp = get(CONTEXT).getApp(1).orElse(null);
 
         // Not setting insertion point
         if(previousApp == null) {
             return;
         }
-        
+
         // Find target node in previous app is target has valid location
         var newTarget = target;
         if(target.getLocation().isValid()) {
             newTarget = previousApp.find(target).orElse(null);
 
-            /*
-            if(newTarget == null) {
-                System.out.println("Could not find corresponding node");
-            } else {
-                System.out.println("Found node in previous app. Are they the same instance? " + (newTarget == target));
-            }
-             */
         }
-
-        var lambdaTarget = newTarget != null ? newTarget : target;
+*/
         getDescendantsAndSelfStream()
                 //.filter(node -> !node.get(ClavaNode.LOCATION).isValid())
-                .forEach(node -> node.set(ClavaNode.INSERTION_POINT, Optional.of(lambdaTarget)));
+                .forEach(node -> node.set(ClavaNode.ORIGIN, Optional.of(target)));
     }
 }

--- a/ClavaAst/src/pt/up/fe/specs/clava/ClavaNode.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ClavaNode.java
@@ -121,7 +121,7 @@ public abstract class ClavaNode extends ATreeNode<ClavaNode>
     /**
      * If this node was not originally from the AST, contains the node that was used as an insertion point.
      */
-    public final static DataKey<Optional<ClavaNode>> ORIGIN = KeyFactory.optional("insertionPoint");
+    public final static DataKey<ClavaNode> ORIGIN = KeyFactory.object("origin", ClavaNode.class);
 
     /// DATAKEYS END
 
@@ -346,7 +346,7 @@ public abstract class ClavaNode extends ATreeNode<ClavaNode>
         ClavaNode newToken = overridesCopyPrivate ? copyPrivate() : copyPrivate(keepId);
 
         // Set origin
-        newToken.set(ORIGIN, Optional.of(this));
+        newToken.set(ORIGIN, this);
 
         // Check new token does not have children
         if (newToken.getNumChildren() != 0) {
@@ -1542,6 +1542,6 @@ public abstract class ClavaNode extends ATreeNode<ClavaNode>
 */
         getDescendantsAndSelfStream()
                 //.filter(node -> !node.get(ClavaNode.LOCATION).isValid())
-                .forEach(node -> node.set(ClavaNode.ORIGIN, Optional.of(target)));
+                .forEach(node -> node.set(ClavaNode.ORIGIN, target));
     }
 }

--- a/ClavaAst/src/pt/up/fe/specs/clava/ClavaNodes.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ClavaNodes.java
@@ -557,7 +557,7 @@ public class ClavaNodes {
         switch (position) {
         case BEFORE:
             Stmt beforeNode = snippetParser.parseStmt(code);
-            beforeNode.setInsertionPoint(target);
+            beforeNode.setOrigin(target);
             realTarget = getValidStatement(target, position);
             if (realTarget == null) {
                 return null;
@@ -571,7 +571,7 @@ public class ClavaNodes {
         case AFTER:
 
             Stmt afterNode = snippetParser.parseStmt(code);
-            afterNode.setInsertionPoint(target);
+            afterNode.setOrigin(target);
             realTarget = getValidStatement(target, position);
             if (realTarget == null) {
                 return null;
@@ -582,7 +582,7 @@ public class ClavaNodes {
         case REPLACE:
             // Has to replace with a node of the same "kind" (e.g., Expr, Stmt...)
             ClavaNode replaceNode = ClavaNodes.toLiteral(code, target.getFactory().nullType(), target);
-            replaceNode.setInsertionPoint(target);
+            replaceNode.setOrigin(target);
             NodeInsertUtils.replace(target, replaceNode);
             return replaceNode;
         default:

--- a/ClavaAst/src/pt/up/fe/specs/clava/ClavaNodes.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ClavaNodes.java
@@ -557,7 +557,7 @@ public class ClavaNodes {
         switch (position) {
         case BEFORE:
             Stmt beforeNode = snippetParser.parseStmt(code);
-
+            beforeNode.setInsertionPoint(target);
             realTarget = getValidStatement(target, position);
             if (realTarget == null) {
                 return null;
@@ -571,6 +571,7 @@ public class ClavaNodes {
         case AFTER:
 
             Stmt afterNode = snippetParser.parseStmt(code);
+            afterNode.setInsertionPoint(target);
             realTarget = getValidStatement(target, position);
             if (realTarget == null) {
                 return null;
@@ -581,6 +582,7 @@ public class ClavaNodes {
         case REPLACE:
             // Has to replace with a node of the same "kind" (e.g., Expr, Stmt...)
             ClavaNode replaceNode = ClavaNodes.toLiteral(code, target.getFactory().nullType(), target);
+            replaceNode.setInsertionPoint(target);
             NodeInsertUtils.replace(target, replaceNode);
             return replaceNode;
         default:

--- a/ClavaAst/src/pt/up/fe/specs/clava/context/ClavaContext.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/context/ClavaContext.java
@@ -151,6 +151,22 @@ public class ClavaContext extends ADataClass<ClavaContext> {
 
         return SpecsCollections.last(appStack);
     }
+
+    /**
+     * Returns the nth app from the top of the stack.<br>
+     * <br>
+     * E.g., if index is 1, returns the App immediately under the top of the stack.
+     * @param index
+     * @return the nth app from the top of the stack, or empty if none exists
+     */
+    public Optional<App> getApp(int index) {
+        if(index >= appStack.size()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(appStack.get(appStack.size()-index-1));
+    }
+
     // public <T> T get(DataKey<T> key) {
     // return this.data.get(key);
     // }

--- a/ClavaLaraApi/src-lara/clava/Joinpoints.js
+++ b/ClavaLaraApi/src-lara/clava/Joinpoints.js
@@ -173,6 +173,10 @@ export class Joinpoint extends LaraJoinPoint {
      */
     get numChildren() { return wrapJoinPoint(this._javaObject.getNumChildren()); }
     /**
+     * If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin
+     */
+    get originNode() { return wrapJoinPoint(this._javaObject.getOriginNode()); }
+    /**
      * Returns the parent node in the AST, or undefined if it is the root node
      */
     get parent() { return wrapJoinPoint(this._javaObject.getParent()); }

--- a/ClavaLaraApi/src-lara/clava/clava/ClavaJoinPoints.js
+++ b/ClavaLaraApi/src-lara/clava/clava/ClavaJoinPoints.js
@@ -158,7 +158,7 @@ export default class ClavaJoinPoints {
             }
             return $normalizedStmt;
         });
-        return wrapJoinPoint(ClavaJavaTypes.AstFactory.scope(unwrapJoinPoint($stmts)));
+        return wrapJoinPoint(ClavaJavaTypes.AstFactory.scope(...unwrapJoinPoint($stmts)));
     }
     static varRef(decl, $type) {
         if (typeof decl === "string") {

--- a/ClavaWeaver/resources/clava/weaverspecs/artifacts.xml
+++ b/ClavaWeaver/resources/clava/weaverspecs/artifacts.xml
@@ -173,6 +173,9 @@ https://docs.google.com/document/d/1uPrvuVBXHSbjDTfehpEeLDz9hgIr8EuJJJvBc5A70rs/
             <def type="string[]" />
             <def type="string" />
         </attribute>
+        <attribute name="originNode" type="joinpoint"
+                   tooltip="If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin">
+        </attribute>
     </global>
 
 

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxActions.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxActions.java
@@ -155,7 +155,7 @@ public class CxxActions {
         weaver.clearUserField(target);
 
         // Set origin point from target to newNode if locations are invalid and no origin point is set
-        newNode.setInsertionPoint(target);
+        newNode.setOrigin(target);
 
 /*
         newNode.getDescendantsAndSelfStream()
@@ -199,7 +199,7 @@ public class CxxActions {
         // Set origin point from target to newNode if locations are invalid and no origin point is set
         var newNode = newJp.getNode();
         var target = baseJp.getNode();
-        newNode.setInsertionPoint(target);
+        newNode.setOrigin(target);
 
 
         // Special case: if this node is a statement in a loop header, insert using a special function.

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxActions.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxActions.java
@@ -155,10 +155,13 @@ public class CxxActions {
         weaver.clearUserField(target);
 
         // Set origin point from target to newNode if locations are invalid and no origin point is set
+        newNode.setInsertionPoint(target);
+
+/*
         newNode.getDescendantsAndSelfStream()
                 .filter(node -> !node.get(ClavaNode.LOCATION).isValid())
                 .forEach(node -> node.set(ClavaNode.INSERTION_POINT, Optional.of(target)));
-
+*/
         return NodeInsertUtils.replace(target, newNode);
     }
 
@@ -196,9 +199,8 @@ public class CxxActions {
         // Set origin point from target to newNode if locations are invalid and no origin point is set
         var newNode = newJp.getNode();
         var target = baseJp.getNode();
-        newNode.getDescendantsAndSelfStream()
-                .filter(node -> !node.get(ClavaNode.LOCATION).isValid())
-                .forEach(node -> node.set(ClavaNode.INSERTION_POINT, Optional.of(target)));
+        newNode.setInsertionPoint(target);
+
 
         // Special case: if this node is a statement in a loop header, insert using a special function.
         if (baseJp.getIsInsideLoopHeaderImpl() && (position != Insert.REPLACE && position != Insert.AROUND)

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxActions.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxActions.java
@@ -154,10 +154,10 @@ public class CxxActions {
     public static ClavaNode replace(ClavaNode target, ClavaNode newNode, CxxWeaver weaver) {
         weaver.clearUserField(target);
 
-        // Copy location from target to newNode if locations are invalid
+        // Set origin point from target to newNode if locations are invalid and no origin point is set
         newNode.getDescendantsAndSelfStream()
                 .filter(node -> !node.get(ClavaNode.LOCATION).isValid())
-                .forEach(node -> node.set(ClavaNode.LOCATION, target.get(ClavaNode.LOCATION)));
+                .forEach(node -> node.set(ClavaNode.INSERTION_POINT, Optional.of(target)));
 
         return NodeInsertUtils.replace(target, newNode);
     }
@@ -192,6 +192,13 @@ public class CxxActions {
 
     public static AJoinPoint insert(AJoinPoint baseJp, AJoinPoint newJp, Insert position,
             BiConsumer<ClavaNode, ClavaNode> insertFunction) {
+
+        // Set origin point from target to newNode if locations are invalid and no origin point is set
+        var newNode = newJp.getNode();
+        var target = baseJp.getNode();
+        newNode.getDescendantsAndSelfStream()
+                .filter(node -> !node.get(ClavaNode.LOCATION).isValid())
+                .forEach(node -> node.set(ClavaNode.INSERTION_POINT, Optional.of(target)));
 
         // Special case: if this node is a statement in a loop header, insert using a special function.
         if (baseJp.getIsInsideLoopHeaderImpl() && (position != Insert.REPLACE && position != Insert.AROUND)
@@ -314,6 +321,14 @@ public class CxxActions {
     // return stmt.get();
     // }
 
+    /**
+     *
+     * @param baseJp
+     * @param newJp
+     * @param position
+     * @param weaver
+     * @return
+     */
     public static AJoinPoint insertJpAsStatement(AJoinPoint baseJp, AJoinPoint newJp, String position,
             CxxWeaver weaver) {
 

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxWeaver.json
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxWeaver.json
@@ -543,6 +543,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -1513,6 +1522,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -2636,6 +2654,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -3773,6 +3800,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -4916,6 +4952,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -5987,6 +6032,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -7030,6 +7084,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -8108,6 +8171,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -9403,6 +9475,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -10384,6 +10465,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -11630,6 +11720,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -12865,6 +12964,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -14016,6 +14124,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -15118,6 +15235,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -16269,6 +16395,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -17673,6 +17808,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -18766,6 +18910,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -19975,6 +20128,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -21035,6 +21197,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -21994,6 +22165,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -22978,6 +23158,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -24206,6 +24395,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -25323,6 +25521,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -26299,6 +26506,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -27376,6 +27592,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -28412,6 +28637,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -29563,6 +29797,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -30613,6 +30856,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -31580,6 +31832,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -32661,6 +32922,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -33851,6 +34121,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -34942,6 +35221,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -35960,6 +36248,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -37037,6 +37334,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -38036,6 +38342,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -39175,6 +39490,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -40466,6 +40790,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -41672,6 +42005,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -43127,6 +43469,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -44233,6 +44584,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -45321,6 +45681,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -46465,6 +46834,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -47459,6 +47837,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -48466,6 +48853,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -49481,6 +49877,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -50479,6 +50884,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -51500,6 +51914,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -52587,6 +53010,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -53738,6 +54170,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -55016,6 +55457,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -56088,6 +56538,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -57263,6 +57722,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -58606,6 +59074,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -59934,6 +60411,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -60970,6 +61456,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -62159,6 +62654,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -63474,6 +63978,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -64535,6 +65048,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -65654,6 +66176,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -66781,6 +67312,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -68024,6 +68564,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -69126,6 +69675,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -70243,6 +70801,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -71564,6 +72131,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -72698,6 +73274,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -73734,6 +74319,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -74852,6 +75446,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -76112,6 +76715,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -77227,6 +77839,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -78291,6 +78912,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -79373,6 +80003,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -80535,6 +81174,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -81779,6 +82427,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -82920,6 +83577,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -83934,6 +84600,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -85057,6 +85732,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -86149,6 +86833,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -87185,6 +87878,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -88364,6 +89066,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -89496,6 +90207,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -90549,6 +91269,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -91673,6 +92402,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -92828,6 +93566,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{
@@ -94074,6 +94821,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -95256,6 +96012,15 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns the parent node in the AST, or undefined if it is the root node",
 						"children": [
 									{
@@ -96257,6 +97022,15 @@
 									{
 										"type": "int",
 										"name": "numChildren"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "originNode"
 									}]
 					},
 					{

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/ACxxWeaverJoinPoint.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/ACxxWeaverJoinPoint.java
@@ -55,7 +55,6 @@ import pt.up.fe.specs.util.SpecsLogs;
 import pt.up.fe.specs.util.SpecsStrings;
 import pt.up.fe.specs.util.exceptions.NotImplementedException;
 import pt.up.fe.specs.util.stringsplitter.StringSplitter;
-import pt.up.fe.specs.util.stringsplitter.StringSplitterRules;
 
 /**
  * Abstract class which can be edited by the developer. This class will not be overwritten.
@@ -1424,8 +1423,8 @@ public abstract class ACxxWeaverJoinPoint extends AJoinPoint {
         var currentNode = getNode();
 
         // Travel insertion points until it finds an origin
-        while(currentNode.get(ClavaNode.INSERTION_POINT).isPresent()) {
-            currentNode = currentNode.get(ClavaNode.INSERTION_POINT).get();
+        while(currentNode.get(ClavaNode.ORIGIN).isPresent()) {
+            currentNode = currentNode.get(ClavaNode.ORIGIN).get();
         }
 
         return CxxJoinpoints.create(currentNode);

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/ACxxWeaverJoinPoint.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/ACxxWeaverJoinPoint.java
@@ -1234,6 +1234,9 @@ public abstract class ACxxWeaverJoinPoint extends AJoinPoint {
     // return CxxSelects.select(joinPointClass, getNode().getChildren(), true, this, filter);
     // }
 
+    /**
+     *
+     */
     @Override
     public void removeChildrenImpl() {
         for (AJoinPoint child : getChildrenArrayImpl()) {
@@ -1414,5 +1417,17 @@ public abstract class ACxxWeaverJoinPoint extends AJoinPoint {
     @Override
     public Boolean getIsInSystemHeaderImpl() {
         return getNode().get(ClavaNode.IS_IN_SYSTEM_HEADER);
+    }
+
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        var currentNode = getNode();
+
+        // Travel insertion points until it finds an origin
+        while(currentNode.get(ClavaNode.INSERTION_POINT).isPresent()) {
+            currentNode = currentNode.get(ClavaNode.INSERTION_POINT).get();
+        }
+
+        return CxxJoinpoints.create(currentNode);
     }
 }

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/ACxxWeaverJoinPoint.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/ACxxWeaverJoinPoint.java
@@ -1422,9 +1422,11 @@ public abstract class ACxxWeaverJoinPoint extends AJoinPoint {
     public AJoinPoint getOriginNodeImpl() {
         var currentNode = getNode();
 
+        // TODO: need to detect cycles?
+
         // Travel insertion points until it finds an origin
-        while(currentNode.get(ClavaNode.ORIGIN).isPresent()) {
-            currentNode = currentNode.get(ClavaNode.ORIGIN).get();
+        while(currentNode.hasValue(ClavaNode.ORIGIN)) {
+            currentNode = currentNode.get(ClavaNode.ORIGIN);
         }
 
         return CxxJoinpoints.create(currentNode);

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/ACxxWeaverJoinPoint.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/ACxxWeaverJoinPoint.java
@@ -1420,15 +1420,6 @@ public abstract class ACxxWeaverJoinPoint extends AJoinPoint {
 
     @Override
     public AJoinPoint getOriginNodeImpl() {
-        var currentNode = getNode();
-
-        // TODO: need to detect cycles?
-
-        // Travel insertion points until it finds an origin
-        while(currentNode.hasValue(ClavaNode.ORIGIN)) {
-            currentNode = currentNode.get(ClavaNode.ORIGIN);
-        }
-
-        return CxxJoinpoints.create(currentNode);
+        return CxxJoinpoints.create(getNode().getOrigin());
     }
 }

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AAccessSpecifier.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AAccessSpecifier.java
@@ -509,6 +509,15 @@ public abstract class AAccessSpecifier extends ADecl {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aDecl.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1014,6 +1023,7 @@ public abstract class AAccessSpecifier extends ADecl {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AAdjustedType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AAdjustedType.java
@@ -685,6 +685,15 @@ public abstract class AAdjustedType extends AType {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aType.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1278,6 +1287,7 @@ public abstract class AAdjustedType extends AType {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AArrayAccess.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AArrayAccess.java
@@ -673,6 +673,15 @@ public abstract class AArrayAccess extends AExpression {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aExpression.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1201,6 +1210,7 @@ public abstract class AArrayAccess extends AExpression {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AArrayType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AArrayType.java
@@ -721,6 +721,15 @@ public abstract class AArrayType extends AType {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aType.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1322,6 +1331,7 @@ public abstract class AArrayType extends AType {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AAttribute.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AAttribute.java
@@ -194,6 +194,7 @@ public abstract class AAttribute extends ACxxWeaverJoinPoint {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ABinaryOp.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ABinaryOp.java
@@ -718,6 +718,15 @@ public abstract class ABinaryOp extends AOp {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aOp.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1261,6 +1270,7 @@ public abstract class ABinaryOp extends AOp {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ABody.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ABody.java
@@ -816,6 +816,15 @@ public abstract class ABody extends AScope {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aScope.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1516,6 +1525,7 @@ public abstract class ABody extends AScope {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ABoolLiteral.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ABoolLiteral.java
@@ -557,6 +557,15 @@ public abstract class ABoolLiteral extends ALiteral {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aLiteral.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1069,6 +1078,7 @@ public abstract class ABoolLiteral extends ALiteral {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ABreak.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ABreak.java
@@ -653,6 +653,15 @@ public abstract class ABreak extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1204,6 +1213,7 @@ public abstract class ABreak extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ABuiltinType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ABuiltinType.java
@@ -802,6 +802,15 @@ public abstract class ABuiltinType extends AType {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aType.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1405,6 +1414,7 @@ public abstract class ABuiltinType extends AType {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ACall.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ACall.java
@@ -1159,6 +1159,15 @@ public abstract class ACall extends AExpression {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aExpression.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1723,6 +1732,7 @@ public abstract class ACall extends AExpression {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ACase.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ACase.java
@@ -788,6 +788,15 @@ public abstract class ACase extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1349,6 +1358,7 @@ public abstract class ACase extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ACast.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ACast.java
@@ -629,6 +629,15 @@ public abstract class ACast extends AExpression {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aExpression.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1147,6 +1156,7 @@ public abstract class ACast extends AExpression {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ACilkFor.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ACilkFor.java
@@ -887,6 +887,15 @@ public abstract class ACilkFor extends ALoop {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aLoop.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1608,6 +1617,7 @@ public abstract class ACilkFor extends ALoop {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ACilkSpawn.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ACilkSpawn.java
@@ -699,6 +699,15 @@ public abstract class ACilkSpawn extends ACall {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aCall.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1304,6 +1313,7 @@ public abstract class ACilkSpawn extends ACall {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ACilkSync.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ACilkSync.java
@@ -628,6 +628,15 @@ public abstract class ACilkSync extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1177,6 +1186,7 @@ public abstract class ACilkSync extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AClass.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AClass.java
@@ -914,6 +914,15 @@ public abstract class AClass extends ARecord {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aRecord.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1484,6 +1493,7 @@ public abstract class AClass extends ARecord {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AClavaException.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AClavaException.java
@@ -248,6 +248,7 @@ public abstract class AClavaException extends ACxxWeaverJoinPoint {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AComment.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AComment.java
@@ -236,6 +236,7 @@ public abstract class AComment extends ACxxWeaverJoinPoint {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AContinue.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AContinue.java
@@ -628,6 +628,15 @@ public abstract class AContinue extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1177,6 +1186,7 @@ public abstract class AContinue extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ACudaKernelCall.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ACudaKernelCall.java
@@ -796,6 +796,15 @@ public abstract class ACudaKernelCall extends ACall {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aCall.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1412,6 +1421,7 @@ public abstract class ACudaKernelCall extends ACall {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ADecl.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ADecl.java
@@ -202,6 +202,7 @@ public abstract class ADecl extends ACxxWeaverJoinPoint {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ADeclStmt.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ADeclStmt.java
@@ -663,6 +663,15 @@ public abstract class ADeclStmt extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1214,6 +1223,7 @@ public abstract class ADeclStmt extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ADeclarator.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ADeclarator.java
@@ -542,6 +542,15 @@ public abstract class ADeclarator extends ANamedDecl {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aNamedDecl.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1097,6 +1106,7 @@ public abstract class ADeclarator extends ANamedDecl {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ADeleteExpr.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ADeleteExpr.java
@@ -529,6 +529,15 @@ public abstract class ADeleteExpr extends AExpression {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aExpression.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1039,6 +1048,7 @@ public abstract class ADeleteExpr extends AExpression {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AElaboratedType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AElaboratedType.java
@@ -731,6 +731,15 @@ public abstract class AElaboratedType extends AType {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aType.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1328,6 +1337,7 @@ public abstract class AElaboratedType extends AType {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AEmpty.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AEmpty.java
@@ -165,6 +165,7 @@ public abstract class AEmpty extends ACxxWeaverJoinPoint {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AEmptyStmt.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AEmptyStmt.java
@@ -628,6 +628,15 @@ public abstract class AEmptyStmt extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1177,6 +1186,7 @@ public abstract class AEmptyStmt extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AEnumDecl.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AEnumDecl.java
@@ -588,6 +588,15 @@ public abstract class AEnumDecl extends ANamedDecl {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aNamedDecl.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1149,6 +1158,7 @@ public abstract class AEnumDecl extends ANamedDecl {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AEnumType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AEnumType.java
@@ -706,6 +706,15 @@ public abstract class AEnumType extends ATagType {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aTagType.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1245,6 +1254,7 @@ public abstract class AEnumType extends ATagType {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AEnumeratorDecl.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AEnumeratorDecl.java
@@ -542,6 +542,15 @@ public abstract class AEnumeratorDecl extends ANamedDecl {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aNamedDecl.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1097,6 +1106,7 @@ public abstract class AEnumeratorDecl extends ANamedDecl {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AExprStmt.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AExprStmt.java
@@ -653,6 +653,15 @@ public abstract class AExprStmt extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1204,6 +1213,7 @@ public abstract class AExprStmt extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AExpression.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AExpression.java
@@ -309,6 +309,7 @@ public abstract class AExpression extends ACxxWeaverJoinPoint {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AField.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AField.java
@@ -542,6 +542,15 @@ public abstract class AField extends ADeclarator {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aDeclarator.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1070,6 +1079,7 @@ public abstract class AField extends ADeclarator {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AFile.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AFile.java
@@ -1139,6 +1139,7 @@ public abstract class AFile extends ACxxWeaverJoinPoint {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AFloatLiteral.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AFloatLiteral.java
@@ -557,6 +557,15 @@ public abstract class AFloatLiteral extends ALiteral {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aLiteral.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1069,6 +1078,7 @@ public abstract class AFloatLiteral extends ALiteral {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AFunction.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AFunction.java
@@ -1665,6 +1665,15 @@ public abstract class AFunction extends ADeclarator {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aDeclarator.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -2301,6 +2310,7 @@ public abstract class AFunction extends ADeclarator {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AFunctionType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AFunctionType.java
@@ -784,6 +784,15 @@ public abstract class AFunctionType extends AType {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aType.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1388,6 +1397,7 @@ public abstract class AFunctionType extends AType {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AGotoStmt.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AGotoStmt.java
@@ -689,6 +689,15 @@ public abstract class AGotoStmt extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1248,6 +1257,7 @@ public abstract class AGotoStmt extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AIf.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AIf.java
@@ -871,6 +871,15 @@ public abstract class AIf extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1472,6 +1481,7 @@ public abstract class AIf extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AImplicitValue.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AImplicitValue.java
@@ -529,6 +529,15 @@ public abstract class AImplicitValue extends AExpression {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aExpression.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1039,6 +1048,7 @@ public abstract class AImplicitValue extends AExpression {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AInclude.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AInclude.java
@@ -555,6 +555,15 @@ public abstract class AInclude extends ADecl {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aDecl.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1064,6 +1073,7 @@ public abstract class AInclude extends ADecl {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AInitList.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AInitList.java
@@ -554,6 +554,15 @@ public abstract class AInitList extends AExpression {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aExpression.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1066,6 +1075,7 @@ public abstract class AInitList extends AExpression {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AIntLiteral.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AIntLiteral.java
@@ -557,6 +557,15 @@ public abstract class AIntLiteral extends ALiteral {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aLiteral.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1069,6 +1078,7 @@ public abstract class AIntLiteral extends ALiteral {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AJoinPoint.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AJoinPoint.java
@@ -831,6 +831,7 @@ public abstract class AJoinPoint extends JoinPoint {
         attributes.add("scopeNodes");
         attributes.add("stmt");
         attributes.add("inlineComments");
+        attributes.add("originNode");
     }
 
     /**
@@ -2469,6 +2470,29 @@ public abstract class AJoinPoint extends JoinPoint {
         	return result!=null?result:getUndefinedValue();
         } catch(Exception e) {
         	throw new AttributeException(get_class(), "inlineComments", e);
+        }
+    }
+
+    /**
+     * If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin
+     */
+    public abstract AJoinPoint getOriginNodeImpl();
+
+    /**
+     * If this join point was not originally from the parsed AST, returns the first join point of the original AST that contributed to its origin
+     */
+    public final Object getOriginNode() {
+        try {
+        	if(hasListeners()) {
+        		eventTrigger().triggerAttribute(Stage.BEGIN, this, "originNode", Optional.empty());
+        	}
+        	AJoinPoint result = this.getOriginNodeImpl();
+        	if(hasListeners()) {
+        		eventTrigger().triggerAttribute(Stage.END, this, "originNode", Optional.ofNullable(result));
+        	}
+        	return result!=null?result:getUndefinedValue();
+        } catch(Exception e) {
+        	throw new AttributeException(get_class(), "originNode", e);
         }
     }
 

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ALabelDecl.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ALabelDecl.java
@@ -542,6 +542,15 @@ public abstract class ALabelDecl extends ANamedDecl {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aNamedDecl.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1097,6 +1106,7 @@ public abstract class ALabelDecl extends ANamedDecl {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ALabelStmt.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ALabelStmt.java
@@ -689,6 +689,15 @@ public abstract class ALabelStmt extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1248,6 +1257,7 @@ public abstract class ALabelStmt extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ALiteral.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ALiteral.java
@@ -529,6 +529,15 @@ public abstract class ALiteral extends AExpression {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aExpression.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1039,6 +1048,7 @@ public abstract class ALiteral extends AExpression {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ALoop.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ALoop.java
@@ -1493,6 +1493,15 @@ public abstract class ALoop extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -2148,6 +2157,7 @@ public abstract class ALoop extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AMarker.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AMarker.java
@@ -579,6 +579,15 @@ public abstract class AMarker extends APragma {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aPragma.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1114,6 +1123,7 @@ public abstract class AMarker extends APragma {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AMemberAccess.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AMemberAccess.java
@@ -706,6 +706,15 @@ public abstract class AMemberAccess extends AExpression {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aExpression.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1234,6 +1243,7 @@ public abstract class AMemberAccess extends AExpression {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AMemberCall.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AMemberCall.java
@@ -751,6 +751,15 @@ public abstract class AMemberCall extends ACall {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aCall.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1360,6 +1369,7 @@ public abstract class AMemberCall extends ACall {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AMethod.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AMethod.java
@@ -872,6 +872,15 @@ public abstract class AMethod extends AFunction {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aFunction.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1620,6 +1629,7 @@ public abstract class AMethod extends AFunction {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ANamedDecl.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ANamedDecl.java
@@ -686,6 +686,15 @@ public abstract class ANamedDecl extends ADecl {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aDecl.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1221,6 +1230,7 @@ public abstract class ANamedDecl extends ADecl {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ANewExpr.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ANewExpr.java
@@ -529,6 +529,15 @@ public abstract class ANewExpr extends AExpression {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aExpression.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1039,6 +1048,7 @@ public abstract class ANewExpr extends AExpression {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AOmp.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AOmp.java
@@ -1547,6 +1547,15 @@ public abstract class AOmp extends APragma {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aPragma.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -2144,6 +2153,7 @@ public abstract class AOmp extends APragma {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AOp.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AOp.java
@@ -604,6 +604,15 @@ public abstract class AOp extends AExpression {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aExpression.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1120,6 +1129,7 @@ public abstract class AOp extends AExpression {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AParam.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AParam.java
@@ -621,6 +621,15 @@ public abstract class AParam extends AVardecl {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aVardecl.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1210,6 +1219,7 @@ public abstract class AParam extends AVardecl {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AParenExpr.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AParenExpr.java
@@ -554,6 +554,15 @@ public abstract class AParenExpr extends AExpression {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aExpression.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1066,6 +1075,7 @@ public abstract class AParenExpr extends AExpression {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AParenType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AParenType.java
@@ -721,6 +721,15 @@ public abstract class AParenType extends AType {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aType.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1322,6 +1331,7 @@ public abstract class AParenType extends AType {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/APointerType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/APointerType.java
@@ -744,6 +744,15 @@ public abstract class APointerType extends AType {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aType.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1347,6 +1356,7 @@ public abstract class APointerType extends AType {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/APragma.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/APragma.java
@@ -350,6 +350,7 @@ public abstract class APragma extends ACxxWeaverJoinPoint {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AProgram.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AProgram.java
@@ -1002,6 +1002,7 @@ public abstract class AProgram extends ACxxWeaverJoinPoint {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AQualType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AQualType.java
@@ -722,6 +722,15 @@ public abstract class AQualType extends AType {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aType.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1317,6 +1326,7 @@ public abstract class AQualType extends AType {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ARecord.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ARecord.java
@@ -721,6 +721,15 @@ public abstract class ARecord extends ANamedDecl {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aNamedDecl.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1291,6 +1300,7 @@ public abstract class ARecord extends ANamedDecl {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AReturnStmt.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AReturnStmt.java
@@ -664,6 +664,15 @@ public abstract class AReturnStmt extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1219,6 +1228,7 @@ public abstract class AReturnStmt extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AScope.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AScope.java
@@ -1225,6 +1225,15 @@ public abstract class AScope extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1858,6 +1867,7 @@ public abstract class AScope extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AStatement.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AStatement.java
@@ -402,6 +402,7 @@ public abstract class AStatement extends ACxxWeaverJoinPoint {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AStruct.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AStruct.java
@@ -596,6 +596,15 @@ public abstract class AStruct extends ARecord {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aRecord.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1141,6 +1150,7 @@ public abstract class AStruct extends ARecord {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ASwitch.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ASwitch.java
@@ -732,6 +732,15 @@ public abstract class ASwitch extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1289,6 +1298,7 @@ public abstract class ASwitch extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ATag.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ATag.java
@@ -545,6 +545,15 @@ public abstract class ATag extends APragma {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aPragma.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1074,6 +1083,7 @@ public abstract class ATag extends APragma {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ATagType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ATagType.java
@@ -710,6 +710,15 @@ public abstract class ATagType extends AType {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aType.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1305,6 +1314,7 @@ public abstract class ATagType extends AType {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ATemplateSpecializationType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ATemplateSpecializationType.java
@@ -772,6 +772,15 @@ public abstract class ATemplateSpecializationType extends AType {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aType.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1371,6 +1380,7 @@ public abstract class ATemplateSpecializationType extends AType {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ATernaryOp.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ATernaryOp.java
@@ -680,6 +680,15 @@ public abstract class ATernaryOp extends AOp {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aOp.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1232,6 +1241,7 @@ public abstract class ATernaryOp extends AOp {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AThis.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AThis.java
@@ -529,6 +529,15 @@ public abstract class AThis extends AExpression {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aExpression.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1039,6 +1048,7 @@ public abstract class AThis extends AExpression {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AType.java
@@ -895,6 +895,7 @@ public abstract class AType extends ACxxWeaverJoinPoint {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ATypedefDecl.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ATypedefDecl.java
@@ -542,6 +542,15 @@ public abstract class ATypedefDecl extends ATypedefNameDecl {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aTypedefNameDecl.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1070,6 +1079,7 @@ public abstract class ATypedefDecl extends ATypedefNameDecl {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ATypedefNameDecl.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ATypedefNameDecl.java
@@ -542,6 +542,15 @@ public abstract class ATypedefNameDecl extends ANamedDecl {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aNamedDecl.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1097,6 +1106,7 @@ public abstract class ATypedefNameDecl extends ANamedDecl {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ATypedefType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/ATypedefType.java
@@ -708,6 +708,15 @@ public abstract class ATypedefType extends AType {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aType.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1303,6 +1312,7 @@ public abstract class ATypedefType extends AType {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AUnaryExprOrType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AUnaryExprOrType.java
@@ -690,6 +690,15 @@ public abstract class AUnaryExprOrType extends AExpression {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aExpression.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1218,6 +1227,7 @@ public abstract class AUnaryExprOrType extends AExpression {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AUnaryOp.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AUnaryOp.java
@@ -618,6 +618,15 @@ public abstract class AUnaryOp extends AOp {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aOp.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1139,6 +1148,7 @@ public abstract class AUnaryOp extends AOp {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AUndefinedType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AUndefinedType.java
@@ -660,6 +660,15 @@ public abstract class AUndefinedType extends AType {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aType.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1251,6 +1260,7 @@ public abstract class AUndefinedType extends AType {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AVardecl.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AVardecl.java
@@ -851,6 +851,15 @@ public abstract class AVardecl extends ADeclarator {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aDeclarator.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1409,6 +1418,7 @@ public abstract class AVardecl extends ADeclarator {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AVariableArrayType.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AVariableArrayType.java
@@ -738,6 +738,15 @@ public abstract class AVariableArrayType extends AArrayType {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aArrayType.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1300,6 +1309,7 @@ public abstract class AVariableArrayType extends AArrayType {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AVarref.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AVarref.java
@@ -732,6 +732,15 @@ public abstract class AVarref extends AExpression {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aExpression.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1264,6 +1273,7 @@ public abstract class AVarref extends AExpression {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AWrapperStmt.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/joinpoints/AWrapperStmt.java
@@ -680,6 +680,15 @@ public abstract class AWrapperStmt extends AStatement {
     }
 
     /**
+     * Get value on attribute originNode
+     * @return the attribute's value
+     */
+    @Override
+    public AJoinPoint getOriginNodeImpl() {
+        return this.aStatement.getOriginNodeImpl();
+    }
+
+    /**
      * Get value on attribute column
      * @return the attribute's value
      */
@@ -1233,6 +1242,7 @@ public abstract class AWrapperStmt extends AStatement {
         GETDESCENDANTSANDSELF("getDescendantsAndSelf"),
         CHAIN("chain"),
         CURRENTREGION("currentRegion"),
+        ORIGINNODE("originNode"),
         COLUMN("column"),
         PARENTREGION("parentRegion"),
         GETVALUE("getValue"),

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/weaver/ACxxWeaver.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/abstracts/weaver/ACxxWeaver.java
@@ -9,8 +9,8 @@ import java.util.ArrayList;
 
 /**
  * Abstract Weaver Implementation for CxxWeaver<br>
- * Since the generated abstract classes are always overwritten, their implementation should be done by extending those abstract classes with user-defined classes.<br>
- * The abstract class {@link pt.up.fe.specs.clava.weaver.abstracts.ACxxWeaverJoinPoint} can be used to add user-defined methods and fields which the user intends to add for all join points and are not intended to be used in LARA aspects.
+Since the generated abstract classes are always overwritten, their implementation should be done by extending those abstract classes with user-defined classes.<br>
+The abstract class {@link pt.up.fe.specs.clava.weaver.abstracts.ACxxWeaverJoinPoint} can be used to add user-defined methods and fields which the user intends to add for all join points and are not intended to be used in LARA aspects.
  * The implementation of the abstract methods is mandatory!
  * @author Lara C.
  */


### PR DESCRIPTION
Adds global attribute $jp.originNode, which allows to fetch what code was originally associated with a node, even after several transformations in the AST.

If Clava.pushAst() is done before the transformations, allows to access the original code for any node.