### PR TITLE
Feature/ast visualization

### DIFF
--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -272,9 +272,23 @@ export default class ClavaAstConverter implements GenericAstConverter {
     const rootCodeNode = this.toCodeNode(root as Joinpoint);
     this.refineCode(rootCodeNode);
 
-    let code = rootCodeNode.children[0].code;
-    code = this.escapeHtml(code);
-    code = this.linkCodeToAstNodes(rootCodeNode.children[0], code, 0, code.length)[2];
-    return { "": code };
+    if (root instanceof Program) {
+      return Object.fromEntries(rootCodeNode.children.map(child => {
+        const file = child.children[0];
+        const filename = (file.jp as FileJp).name;
+
+        const fileCode = child.code;  // same as file.code
+        const fileHtmlCode = this.escapeHtml(fileCode);
+        const fileLinkedHtmlCode = this.linkCodeToAstNodes(child, fileHtmlCode, 0, fileHtmlCode.length)[2];
+        return [filename, fileLinkedHtmlCode];
+      }));
+    } else {
+      const filename = (root as Joinpoint).filename;
+      const code = rootCodeNode.code;
+      const htmlCode = this.escapeHtml(code);
+      const linkedHtmlCode = this.linkCodeToAstNodes(rootCodeNode, htmlCode, 0, htmlCode.length)[2];
+
+      return { [filename]: linkedHtmlCode };
+    }
   }
 }

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -2,59 +2,117 @@ import { LaraJoinPoint } from "lara-js/api/LaraJoinPoint.js";
 import GenericAstConverter from "lara-js/api/visualization/GenericAstConverter.js";
 import ToolJoinPoint from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
 import { Joinpoint } from "../Joinpoints.js";
+import Clava from "../clava/Clava.js";
+
+type CodeMap = { [nodeId: string]: string };
 
 export default class ClavaAstConverter implements GenericAstConverter {
-  private sortByLocation(jps: Joinpoint[]): Joinpoint[] {
-    return jps.sort((jp1, jp2) => jp1.location.localeCompare(jp2.location, 'en', { numeric: true }));
-  }
-
-  private toToolJoinPoint(jp: LaraJoinPoint): ToolJoinPoint {
-    const clavaJp = jp as Joinpoint;
-    const sortedChildren = this.sortByLocation(clavaJp.children.slice());
+  public getToolAst(root: LaraJoinPoint): ToolJoinPoint {
+    const clavaJp = root as Joinpoint;
     
     return new ToolJoinPoint(
       clavaJp.astId,
       clavaJp.joinPointType,
       clavaJp.code,
-      sortedChildren.map(child => this.toToolJoinPoint(child)),
+      clavaJp.children.map(child => this.getToolAst(child)),
     );
+  }
+
+  private toCodeMap(jp: Joinpoint, codeMap: CodeMap): CodeMap {
+    codeMap[jp.astId] = jp.code.trim();
+    jp.children.forEach(child => this.toCodeMap(child, codeMap));
+    return codeMap;
   }
 
   private addIdentation(code: string, indentation: number): string {
     return code.split('\n').map((line, i) => i > 0 ? '   '.repeat(indentation) + line : line).join('\n');
   }
 
-  private refineAstCode(root: ToolJoinPoint, indentation: number = 0): ToolJoinPoint {
-    root.code = this.addIdentation(root.code.trim(), indentation);
+  private refineCodeMap(root: Joinpoint, codeMap: CodeMap, indentation: number = 0): CodeMap {
+    codeMap[root.astId] = this.addIdentation(codeMap[root.astId], indentation);
 
-    const children = root.children;
-    if (root.type == 'loop') {
-      children
-        .filter(child => child.type === 'exprStmt')
-        .forEach(child => child.code = child.code.slice(0, -1));	// Remove semicolon from expression statements inside loop parentheses
+    if (root.joinPointType == 'loop') {
+      root.children
+        .filter(child => child.joinPointType === 'exprStmt')
+        .forEach(child => codeMap[child.astId] = codeMap[child.astId].slice(0, -1));	// Remove semicolon from expression statements inside loop parentheses
     }
 
-    if (root.type == 'declStmt') {
+    if (root.joinPointType == 'declStmt') {
       root.children
         .slice(1)
         .forEach(child => {
-          child.code = child.code.match(/(?:\S+\s+)(\S.*)/)![1];
+          codeMap[child.astId] = codeMap[child.astId].match(/(?:\S+\s+)(\S.*)/)![1];
         });  // Remove type from variable declarations
     }
 
-
     for (const child of root.children) {
-      this.refineAstCode(child, ['body', 'class'].includes(root.type) ? indentation + 1 : indentation);
+      const newIndentation = ['body', 'class'].includes(root.joinPointType) ? indentation + 1 : indentation;
+      this.refineCodeMap(child, codeMap, newIndentation);
     }
 
-    return root;
+    return codeMap;
   }
 
-  public getToolAst(root: LaraJoinPoint): ToolJoinPoint {
-    return this.refineAstCode(this.toToolJoinPoint(root));
+  private escapeHtml(text: string): string {
+    const specialCharMap: { [char: string]: string } = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+    };
+    
+    return text.replace(/[&<>]/g, (match) => specialCharMap[match]);
+  }
+
+  private getSpanTags(attrs: string[]): string[] {
+    return [`<span ${attrs.join(' ')}>`, '</span>'];
+  }
+
+  private getNodeCodeTags(nodeId: string): string[] {
+    return this.getSpanTags(['class="node-code"', `data-node-id="${nodeId}"`]);
+  }
+
+  private sortByLocation(jps: Joinpoint[]): Joinpoint[] {
+    return jps.sort((jp1, jp2) => jp1.location.localeCompare(jp2.location, 'en', { numeric: true }));
+  }
+
+  private linkCodeToAstNodes(root: Joinpoint, codeMap: CodeMap, outerCode: string, outerCodeStart: number, outerCodeEnd: number): any[] {
+    const nodeCode = codeMap[root.astId];
+    const nodeCodeHtml = this.escapeHtml(nodeCode);
+    const innerCodeStart = outerCode.indexOf(nodeCodeHtml, outerCodeStart);
+    const innerCodeEnd = innerCodeStart + nodeCodeHtml.length;
+    if (innerCodeStart === -1 || innerCodeEnd > outerCodeEnd) {
+      console.warn(`Code of node "${root.joinPointType}" not found in code container: "${nodeCodeHtml}"`);
+      return [outerCodeStart, outerCodeStart, ""];
+    }
+    if (root.joinPointType === 'varref' && nodeCode === 'i') {
+      console.warn(outerCode.slice(outerCodeStart, outerCodeEnd), innerCodeStart)
+    }
+
+    const [openingTag, closingTag] = this.getNodeCodeTags(root.astId);
+
+    let newCode = openingTag;
+    let newCodeIndex = innerCodeStart;
+
+    const sortedChildren = this.sortByLocation(root.children.slice());
+    for (const child of sortedChildren) {
+      const [childCodeStart, childCodeEnd, childCode] = this.linkCodeToAstNodes(child, codeMap, outerCode, newCodeIndex, innerCodeEnd);
+      newCode += outerCode.slice(newCodeIndex, childCodeStart) + childCode;
+      newCodeIndex = childCodeEnd;
+    }
+    newCode += outerCode.slice(newCodeIndex, innerCodeEnd) + closingTag;
+
+    return [innerCodeStart, innerCodeEnd, newCode];
   }
 
   public getPrettyHtmlCode(): string {
-    return '';
+    const root = Clava.getProgram();
+    const codeMap: CodeMap = {};
+    this.toCodeMap(root, codeMap);
+    this.refineCodeMap(root, codeMap);
+
+    let code = codeMap[root.astId];
+    code = this.escapeHtml(code);
+    code = this.linkCodeToAstNodes(root, codeMap, code, 0, code.length)[2];
+    return code;
   }
 }

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -290,7 +290,7 @@ export default class ClavaAstConverter implements GenericAstConverter {
     if (node.jp instanceof Declarator || node.jp instanceof EnumeratorDecl) {
       const [openingTag, closingTag] = this.getSpanTags('class="type"');
 
-      const regex = new RegExp(`\\s*[&*]*${node.jp.name}\\b`);
+      const regex = new RegExp(`\\s*[&*]*\\b${node.jp.name}\\b`);
       const namePos = code.search(regex);
       return namePos <= 0 ? code : openingTag + code.slice(0, namePos) + closingTag + code.slice(namePos);
     }

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -279,10 +279,14 @@ export default class ClavaAstConverter implements GenericAstConverter {
       const [openingTag, closingTag] = this.getSpanTags('class="literal"');
       return openingTag + code + closingTag;
     }
-    if (node.jp instanceof Comment) {
-      const [openingTag, closingTag] = this.getSpanTags('class="comment"');
+
+    const [openingTag, closingTag] = this.getSpanTags('class="comment"');
+    if (node.jp instanceof Comment)
       return openingTag + code + closingTag;
-    }
+
+    code = code.replaceAll(/(?<!>)(\/\/.*)/g, `${openingTag}$1${closingTag}`);
+    code = code.replaceAll(/(?<!>)(\/\*.*?\*\/)/g, `${openingTag}$1${closingTag}`);
+    
     if (node.jp instanceof Statement || node.jp instanceof Decl) {
       const [openingTag, closingTag] = this.getSpanTags('class="keyword"');
 
@@ -294,7 +298,7 @@ export default class ClavaAstConverter implements GenericAstConverter {
       }
 
       if (node.jp instanceof If) {
-        const elsePos = code.search(/(?<!(\/\/.*|>))\belse\b/);
+        const elsePos = code.search(/(?<!>)\belse\b/);
         if (elsePos !== -1) {
           return openingTag + 'if' + closingTag + code.slice(2, elsePos) + openingTag + 'else' + closingTag + code.slice(elsePos + 4);
         } else {
@@ -304,8 +308,7 @@ export default class ClavaAstConverter implements GenericAstConverter {
 
       if (node.jp instanceof Loop) {
         if (node.jp.kind == "dowhile") {
-          const loopBodyEndPos = code.indexOf(node.children[0].code!) + node.children[0].code!.length;
-          const whilePos = code.indexOf('while', loopBodyEndPos);
+          const whilePos = code.search(/(?<!>)\while\b/);
           return openingTag + 'do' + closingTag + code.slice(2, whilePos) + openingTag + 'while' + closingTag + code.slice(whilePos + 5);
         } else {
           return code.replace(/^(\w+)(\W.*)$/s, `${openingTag}$1${closingTag}$2`);  // Highlight first word

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -1,7 +1,7 @@
 import { LaraJoinPoint } from "lara-js/api/LaraJoinPoint.js";
 import GenericAstConverter from "lara-js/api/visualization/GenericAstConverter.js";
-import ToolJoinPoint from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
-import { Body, Joinpoint } from "../Joinpoints.js";
+import ToolJoinPoint, { JoinPointInfo } from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
+import { Body, IntLiteral, Joinpoint } from "../Joinpoints.js";
 import Clava from "../clava/Clava.js";
 
 type CodeNode = {
@@ -11,13 +11,29 @@ type CodeNode = {
 };
 
 export default class ClavaAstConverter implements GenericAstConverter {
+  private getJoinPointInfo(jp: Joinpoint): JoinPointInfo {
+    const info: JoinPointInfo = {
+      'astId': jp.astId,
+      'astName': jp.astName,
+    };
+
+    switch (jp.joinPointType) {
+      case 'intLiteral':
+        const intLiteral = jp as IntLiteral;
+        info['value'] = intLiteral.value.toString();
+        break;
+    }
+
+    return info;
+  }
+
   public getToolAst(root: LaraJoinPoint): ToolJoinPoint {
     const clavaJp = root as Joinpoint;
     
     return new ToolJoinPoint(
       clavaJp.astId,
       clavaJp.joinPointType,
-      {},
+      this.getJoinPointInfo(clavaJp),
       clavaJp.children.map(child => this.getToolAst(child)),
     );
   }

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -303,12 +303,13 @@ export default class ClavaAstConverter implements GenericAstConverter {
         || node.jp instanceof EnumDecl || node.jp instanceof AccessSpecifier
         || node.jp.astName == "FunctionTemplateDecl" || node.jp.astName == "TemplateTypeParmDecl") {
 
-        return code.replace(/^(\w+)(?=\W)/s, `${openingTag}$1${closingTag}`);  // Highlight first word
+        return code.replace(/^(\w+)\b/s, `${openingTag}$1${closingTag}`);  // Highlight first word
       }
 
       if (node.jp instanceof If) {
-        const elsePos = code.search(/(?<!>)\belse\b/);
-        if (elsePos !== -1) {
+        const elseMatch = code.match(/^(([^/]|\/[^/*]|\/\/.*|\/\*([^*]|\*[^/])*\*\/)*?)(?<!>)\belse\b/);
+        if (elseMatch) {
+          const elsePos = elseMatch[1].length;
           return openingTag + 'if' + closingTag + code.slice(2, elsePos) + openingTag + 'else' + closingTag + code.slice(elsePos + 4);
         } else {
         return openingTag + 'if' + closingTag + code.slice(2);
@@ -317,7 +318,7 @@ export default class ClavaAstConverter implements GenericAstConverter {
 
       if (node.jp instanceof Loop) {
         if (node.jp.kind == "dowhile") {
-          const whilePos = code.search(/(?<!>)\while\b/);
+          const whilePos = code.match(/^(([^/]|\/[^/*]|\/\/.*|\/\*([^*]|\*[^/])*\*\/)*?)(?<!>)\bwhile\b/)![1].length;
           return openingTag + 'do' + closingTag + code.slice(2, whilePos) + openingTag + 'while' + closingTag + code.slice(whilePos + 5);
         } else {
           return code.replace(/^(\w+)(?=\W)/s, `${openingTag}$1${closingTag}`);  // Highlight first word
@@ -329,11 +330,11 @@ export default class ClavaAstConverter implements GenericAstConverter {
       }
 
       if (node.jp instanceof RecordJp) {
-        return code.replace(/^(.*?)(class(?!=)|struct)(.*)$/s, `$1${openingTag}$2${closingTag}$3`);  // Highlight 'class' or 'struct' in declaration
+        return code.replace(/(class(?!=)|struct)/s, `$1${openingTag}$2${closingTag}$3`);  // Highlight 'class' or 'struct' in declaration
       }
 
       if (node.jp instanceof Include || node.jp instanceof Pragma) {
-        return code.replace(/^(#\w+)(?=\W)/s, `${openingTag}$1${closingTag}`);
+        return code.replace(/^(#\w+)\b/s, `${openingTag}$1${closingTag}`);
       }
     }
 

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -13,7 +13,6 @@ export default class ClavaAstConverter implements GenericAstConverter {
     return new ToolJoinPoint(
       clavaJp.astId,
       clavaJp.joinPointType,
-      clavaJp.code,
       clavaJp.children.map(child => this.getToolAst(child)),
     );
   }

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -2,6 +2,7 @@ import { LaraJoinPoint } from "lara-js/api/LaraJoinPoint.js";
 import GenericAstConverter, { FilesCode } from "lara-js/api/visualization/GenericAstConverter.js";
 import ToolJoinPoint, { JoinPointInfo } from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
 import { AccessSpecifier, AdjustedType, Body, BoolLiteral, Break, Call, Case, Class, Comment, Continue, Decl, Declarator, DeclStmt, EnumDecl, EnumeratorDecl, ExprStmt, FileJp, FloatLiteral, FunctionJp, GotoStmt, If, Include, IntLiteral, Joinpoint, Literal, Loop, Marker, NamedDecl, Omp, Pragma, Program, RecordJp, ReturnStmt, Scope, Statement, Switch, Tag, Type, TypedefDecl, Vardecl, Varref, WrapperStmt } from "../Joinpoints.js";
+import Clava from "../clava/Clava.js";
 
 type CodeNode = {
   jp: Joinpoint;
@@ -11,6 +12,10 @@ type CodeNode = {
 };
 
 export default class ClavaAstConverter implements GenericAstConverter {
+  public updateAst(): void {
+    Clava.rebuild();
+  }
+
   private getJoinPointInfo(jp: Joinpoint): JoinPointInfo {
     const info: JoinPointInfo = {
       'AST ID': jp.astId,

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -2,7 +2,6 @@ import { LaraJoinPoint } from "lara-js/api/LaraJoinPoint.js";
 import GenericAstConverter from "lara-js/api/visualization/GenericAstConverter.js";
 import ToolJoinPoint, { JoinPointInfo } from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
 import { AdjustedType, Body, BoolLiteral, Call, Class, FileJp, FloatLiteral, Include, IntLiteral, Joinpoint, Loop, Marker, NamedDecl, Omp, Pragma, Program, Tag, Type, TypedefDecl, Varref, WrapperStmt } from "../Joinpoints.js";
-import Clava from "../clava/Clava.js";
 
 type CodeNode = {
   jp: Joinpoint;
@@ -265,9 +264,8 @@ export default class ClavaAstConverter implements GenericAstConverter {
     return [innerCodeStart, innerCodeEnd, newCode];
   }
 
-  public getPrettyHtmlCode(): string {
-    const root = Clava.getProgram();
-    const rootCodeNode = this.toCodeNode(root);
+  public getPrettyHtmlCode(root: LaraJoinPoint): string {
+    const rootCodeNode = this.toCodeNode(root as Joinpoint);
     this.refineCode(rootCodeNode);
 
     let code = rootCodeNode.code;

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -144,7 +144,7 @@ export default class ClavaAstConverter implements GenericAstConverter {
       return new ToolJoinPoint(
         (nextId++).toString(),
         jp.joinPointType,
-        code ?? '',
+        code,
         jp.filename,
         this.getJoinPointInfo(jp),
         jp.children.map(child => toToolJoinPoint(child)),

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -303,7 +303,7 @@ export default class ClavaAstConverter implements GenericAstConverter {
         || node.jp instanceof EnumDecl || node.jp instanceof AccessSpecifier
         || node.jp.astName == "FunctionTemplateDecl" || node.jp.astName == "TemplateTypeParmDecl") {
 
-        return code.replace(/^(\w+)\b/s, `${openingTag}$1${closingTag}`);  // Highlight first word
+        return code.replace(/^(\w+)\b/, `${openingTag}$1${closingTag}`);  // Highlight first word
       }
 
       if (node.jp instanceof If) {
@@ -321,7 +321,7 @@ export default class ClavaAstConverter implements GenericAstConverter {
           const whilePos = code.match(/^(([^/]|\/[^/*]|\/\/.*|\/\*([^*]|\*[^/])*\*\/)*?)(?<!>)\bwhile\b/)![1].length;
           return openingTag + 'do' + closingTag + code.slice(2, whilePos) + openingTag + 'while' + closingTag + code.slice(whilePos + 5);
         } else {
-          return code.replace(/^(\w+)(?=\W)/s, `${openingTag}$1${closingTag}`);  // Highlight first word
+          return code.replace(/^(\w+)\b/, `${openingTag}$1${closingTag}`);  // Highlight first word
         }
       }
 
@@ -330,11 +330,11 @@ export default class ClavaAstConverter implements GenericAstConverter {
       }
 
       if (node.jp instanceof RecordJp) {
-        return code.replace(/(class(?!=)|struct)/s, `$1${openingTag}$2${closingTag}$3`);  // Highlight 'class' or 'struct' in declaration
+        return code.replace(/(class(?!=)|struct)/, `${openingTag}$1${closingTag}`);  // Highlight 'class' or 'struct' in declaration
       }
 
       if (node.jp instanceof Include || node.jp instanceof Pragma) {
-        return code.replace(/^(#\w+)\b/s, `${openingTag}$1${closingTag}`);
+        return code.replace(/^(#\w+)\b/, `${openingTag}$1${closingTag}`);
       }
     }
 

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -17,12 +17,9 @@ export default class ClavaAstConverter implements GenericAstConverter {
     return new ToolJoinPoint(
       clavaJp.astId,
       clavaJp.joinPointType,
+      {},
       clavaJp.children.map(child => this.getToolAst(child)),
     );
-  }
-
-  private sortByLocation(codeNodes: CodeNode[]): CodeNode[] {
-    return codeNodes.sort((node1, node2) => node1.jp.location.localeCompare(node2.jp.location, 'en', { numeric: true }));
   }
 
   private toCodeNode(jp: Joinpoint): CodeNode {
@@ -35,6 +32,10 @@ export default class ClavaAstConverter implements GenericAstConverter {
 
   private addIdentation(code: string, indentation: number): string {
     return code.split('\n').map((line, i) => i > 0 ? '   '.repeat(indentation) + line : line).join('\n');
+  }
+
+  private sortByLocation(codeNodes: CodeNode[]): CodeNode[] {
+    return codeNodes.sort((node1, node2) => node1.jp.location.localeCompare(node2.jp.location, 'en', { numeric: true }));
   }
 
   private refineCode(node: CodeNode, indentation: number = 0): CodeNode {

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -1,7 +1,7 @@
 import { LaraJoinPoint } from "lara-js/api/LaraJoinPoint.js";
 import GenericAstConverter, { FilesCode } from "lara-js/api/visualization/GenericAstConverter.js";
 import ToolJoinPoint, { JoinPointInfo } from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
-import { AdjustedType, Body, BoolLiteral, Call, Class, Comment, Decl, DeclStmt, ExprStmt, FileJp, FloatLiteral, Include, IntLiteral, Joinpoint, Literal, Loop, Marker, NamedDecl, Omp, Pragma, Program, Scope, Tag, Type, TypedefDecl, Vardecl, Varref, WrapperStmt } from "../Joinpoints.js";
+import { AccessSpecifier, AdjustedType, Body, BoolLiteral, Break, Call, Case, Class, Comment, Continue, Decl, Declarator, DeclStmt, EnumDecl, EnumeratorDecl, Expression, ExprStmt, FileJp, FloatLiteral, FunctionJp, GotoStmt, If, Include, IntLiteral, Joinpoint, Literal, Loop, Marker, NamedDecl, Omp, Pragma, Program, RecordJp, ReturnStmt, Scope, Statement, Switch, Tag, Type, TypedefDecl, Vardecl, Varref, WrapperStmt } from "../Joinpoints.js";
 
 type CodeNode = {
   jp: Joinpoint;
@@ -269,16 +269,48 @@ export default class ClavaAstConverter implements GenericAstConverter {
       const [openingTag, closingTag] = this.getSpanTags('class="comment"');
       return openingTag + code + closingTag;
     }
-    if (node.jp instanceof NamedDecl) {
-      if (node.jp instanceof Vardecl && node.jp.leftJp instanceof Vardecl)
-        return code;  // Ignore variable declarations without type
-
-      const [openingTag, closingTag] = this.getSpanTags('class="type"');
-      return code.replace(/^(\S*)(\s.*)$/s, `${openingTag}$1${closingTag}$2`);
-    }
-    if (node.jp instanceof Decl) {
+    if (node.jp instanceof Statement || node.jp instanceof Decl) {
       const [openingTag, closingTag] = this.getSpanTags('class="keyword"');
-      return code.replace(/^(\S*)(\s.*)$/s, `${openingTag}$1${closingTag}$2`);
+
+      if (node.jp instanceof Switch || node.jp instanceof Break || node.jp instanceof Case
+        || node.jp instanceof Continue || node.jp instanceof GotoStmt || node.jp instanceof ReturnStmt
+        || node.jp instanceof EnumDecl || node.jp instanceof AccessSpecifier) {
+
+        return code.replace(/^(\w+)(\W.*)$/s, `${openingTag}$1${closingTag}$2`);  // Highlight first word
+      }
+
+      if (node.jp instanceof If) {
+        const elsePos = code.indexOf('else');
+        if (elsePos !== -1) {
+          return openingTag + 'if' + closingTag + code.slice(2, elsePos) + openingTag + 'else' + closingTag + code.slice(elsePos + 4);
+        } else {
+          return openingTag + 'if' + closingTag + code.slice(2);
+        }
+      }
+
+      if (node.jp instanceof Loop) {
+        if (node.jp.kind == "dowhile") {
+          const loopBodyEndPos = code.indexOf(node.children[0].code) + node.children[0].code.length;
+          const whilePos = code.indexOf('while', loopBodyEndPos);
+          return openingTag + 'do' + closingTag + code.slice(2, whilePos) + openingTag + 'while' + closingTag + code.slice(whilePos + 5);
+        } else {
+          return code.replace(/^(\w+)(\W.*)$/s, `${openingTag}$1${closingTag}$2`);  // Highlight first word
+        }
+      }
+
+      if (node.jp instanceof TypedefDecl && node.code.startsWith('typedef')) {
+        return openingTag + 'typedef' + closingTag + code.slice(7);
+      }
+
+      if (node.jp instanceof RecordJp) {
+        return code.replace(/^(.*?)(class(?!=)|struct)(.*)$/s, `$1${openingTag}$2${closingTag}$3`);  // Highlight 'class' or 'struct' in declaration
+      }
+
+      if (node.jp instanceof Include || node.jp instanceof Pragma) {
+        return code.replace(/^(#\w+)(\W.*)$/s, `${openingTag}$1${closingTag}$2`);
+      }
+
+      
     }
 
     return code;
@@ -302,6 +334,10 @@ export default class ClavaAstConverter implements GenericAstConverter {
       newCodeIndex = outerCode.slice(innerCodeStart, innerCodeEnd).search(/[=;]/) + innerCodeStart + 1;
       newCode += outerCode.slice(innerCodeStart, newCodeIndex);
     }  // Ignore variable type and name in declaration
+    if (root.jp instanceof FunctionJp) {
+      newCodeIndex = outerCode.indexOf('(', innerCodeStart) + 1;
+      newCode += outerCode.slice(innerCodeStart, newCodeIndex);
+    }  // Ignore function return type and name in declaration
 
     for (const child of root.children) {
       const [childCodeStart, childCodeEnd, childCode] = this.linkCodeToAstNodes(child, outerCode, newCodeIndex, innerCodeEnd);

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -1,7 +1,7 @@
 import { LaraJoinPoint } from "lara-js/api/LaraJoinPoint.js";
 import GenericAstConverter from "lara-js/api/visualization/GenericAstConverter.js";
 import ToolJoinPoint, { JoinPointInfo } from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
-import { Body, IntLiteral, Joinpoint, TypedefDecl } from "../Joinpoints.js";
+import { AdjustedType, Body, BoolLiteral, Call, Class, FileJp, FloatLiteral, Include, IntLiteral, Joinpoint, Loop, Marker, NamedDecl, Omp, Pragma, Program, Tag, Type, TypedefDecl, Varref, WrapperStmt } from "../Joinpoints.js";
 import Clava from "../clava/Clava.js";
 
 type CodeNode = {
@@ -14,12 +14,123 @@ export default class ClavaAstConverter implements GenericAstConverter {
   private getJoinPointInfo(jp: Joinpoint): JoinPointInfo {
     const info: JoinPointInfo = {
       'AST ID': jp.astId,
-      'AST Name': jp.astName,
+      'AST name': jp.astName,
     };
+
+    if (jp instanceof FileJp) {
+      Object.assign(info, {
+        'File name': jp.name,
+        'Source folder': jp.sourceFoldername,
+        'Relative path': jp.relativeFilepath,
+        'Is C++': jp.isCxx,
+        'Is header file': jp.isHeader,
+        'Has main': jp.hasMain
+      });
+    }
+
+    if (jp instanceof Include) {
+      Object.assign(info, {
+        'Include name': jp.name,
+      });
+    }
+
+    if (jp instanceof NamedDecl) {
+      Object.assign(info, {
+        'Name': jp.name,
+      });
+    }
+
+    if (jp instanceof Pragma) {
+      Object.assign(info, {
+        'Pragma name': jp.name,
+      });
+    }
+
+    if (jp instanceof Program) {
+      Object.assign(info, {
+        'Program name': jp.name,
+        'Standard': jp.standard,
+      });
+    }
+
+    if (jp instanceof Tag) {
+      Object.assign(info, {
+        'Pragma ID': jp.id,
+      });
+    }
+
+    if (jp instanceof Type) {
+      Object.assign(info, {
+        'Constant?': jp.constant,
+        'Is builtin': jp.isBuiltin,
+        'Has sugar': jp.hasSugar,
+      });
+    }
+
+    if (jp instanceof Varref) {
+      Object.assign(info, {
+        'Name': jp.name,
+      });
+    }
+
+    if (jp instanceof WrapperStmt) {
+      Object.assign(info, {
+        'Wrapper type': jp.kind,
+      });
+    }
+
+    if (jp instanceof AdjustedType) {
+      Object.assign(info, {
+        'Original type': jp.originalType,
+      });
+    }
+
+    if (jp instanceof BoolLiteral) {
+      Object.assign(info, {
+        'Value': jp.value.toString(),
+      });
+    }
+
+    if (jp instanceof Call) {
+      Object.assign(info, {
+        'Function name': jp.name,
+      });
+    }
+
+    if (jp instanceof Class) {
+      Object.assign(info, {
+        'Is interface': jp.isInterface,
+      });
+    }
+
+    if (jp instanceof FloatLiteral) {
+      Object.assign(info, {
+        'Value': jp.value.toString(),
+      });
+    }
 
     if (jp instanceof IntLiteral) {
       Object.assign(info, {
         'Value': jp.value.toString(),
+      });
+    }
+
+    if (jp instanceof Loop) {
+      Object.assign(info, {
+        'Loop ID': jp.id,
+        'Loop kind': jp.kind,
+      });
+    }
+
+    if (jp instanceof Marker) {
+      Object.assign(info, {
+        'Marker ID': jp.id,
+      });
+    }
+
+    if (jp instanceof Omp) {
+      Object.assign(info, {
+        'Omp kind': jp.kind,
       });
     }
 

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -385,7 +385,8 @@ export default class ClavaAstConverter implements GenericAstConverter {
     if (root instanceof Program) {
       return Object.fromEntries(rootCodeNode.children.map(child => {
         const file = child.children[0];
-        const filepath = (file.jp as FileJp).path;
+        const fileJp = file.jp as FileJp;
+        const filepath = fileJp.filepath;
 
         const fileCode = child.code!;  // same as file.code!
         const fileHtmlCode = this.escapeHtml(fileCode);

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -133,9 +133,18 @@ export default class ClavaAstConverter implements GenericAstConverter {
   public getToolAst(root: LaraJoinPoint): ToolJoinPoint {
     let nextId = 0;
     const toToolJoinPoint = (jp: Joinpoint): ToolJoinPoint => {
+      let code;
+      try {
+        code = jp.code.trim();
+      } catch (e) {
+        console.error(`Could not get code of node '${jp.joinPointType}': ${e}`);
+        code = undefined;
+      }
+
       return new ToolJoinPoint(
         (nextId++).toString(),
         jp.joinPointType,
+        code ?? '',
         jp.filename,
         this.getJoinPointInfo(jp),
         jp.children.map(child => toToolJoinPoint(child)),

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -1,0 +1,34 @@
+import { LaraJoinPoint } from "lara-js/api/LaraJoinPoint.js";
+import GenericAstConverter from "lara-js/api/visualization/GenericAstConverter.js";
+import ToolJoinPoint from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
+import { Joinpoint } from "../Joinpoints.js";
+
+export default class ClavaAstConverter implements GenericAstConverter {
+  private sortByLocation(jps: Joinpoint[]): Joinpoint[] {
+    return jps.sort((jp1, jp2) => jp1.location.localeCompare(jp2.location, 'en', { numeric: true }));
+  }
+
+  private toToolJoinPoint(jp: LaraJoinPoint): ToolJoinPoint {
+    const clavaJp = jp as Joinpoint;
+    const sortedChildren = this.sortByLocation(clavaJp.children.slice());
+    
+    return new ToolJoinPoint(
+      clavaJp.astId,
+      clavaJp.joinPointType,
+      clavaJp.code,
+      sortedChildren.map(child => this.toToolJoinPoint(child)),
+    );
+  }
+
+  private refineJoinPoint(jp: ToolJoinPoint) {
+    
+  }
+
+  public getToolAst(root: LaraJoinPoint): ToolJoinPoint {
+    return this.toToolJoinPoint(root);
+  }
+
+  public getPrettyHtmlCode(): string {
+    return '';
+  }
+}

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -3,7 +3,7 @@ import GenericAstConverter, { FilesCode } from "lara-js/api/visualization/Generi
 import ToolJoinPoint, { JoinPointInfo } from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
 import { AccessSpecifier, AdjustedType, Body, BoolLiteral, Break, Call, Case, Class, Comment, Continue, Decl, Declarator, DeclStmt, EnumDecl, EnumeratorDecl, ExprStmt, FileJp, FloatLiteral, FunctionJp, GotoStmt, If, Include, IntLiteral, Joinpoint, Literal, Loop, Marker, NamedDecl, Omp, Pragma, Program, RecordJp, ReturnStmt, Scope, Statement, Switch, Tag, Type, TypedefDecl, Vardecl, Varref, WrapperStmt } from "../Joinpoints.js";
 import Clava from "../clava/Clava.js";
-import { addIdentation, escapeHtml, getNodeCodeTags, getSpanTags } from "lara-js/api/visualization/AstConverterUtils.js"
+import { addIdentation, escapeHtml, getNodeCodeTags, getSyntaxHighlightTags } from "lara-js/api/visualization/AstConverterUtils.js"
 
 type CodeNode = {
   jp: Joinpoint;
@@ -18,7 +18,7 @@ export default class ClavaAstConverter implements GenericAstConverter {
   }
 
   private getCode(node: Joinpoint): string | undefined {
-    // When hasCode implementation is ready, replace this method with the following line:
+    // TODO: When hasCode implementation is ready, replace this body with the following line:
     // return node.hasCode ? node.code.trim() : undefined
     let code;
     try {
@@ -253,22 +253,22 @@ export default class ClavaAstConverter implements GenericAstConverter {
       return undefined;
 
     if (node.jp.astName === "StringLiteral") {
-      const [openingTag, closingTag] = getSpanTags('class="string"');
+      const [openingTag, closingTag] = getSyntaxHighlightTags('string');
       return openingTag + code + closingTag;
     }
     if (node.jp instanceof Literal) {
-      const [openingTag, closingTag] = getSpanTags('class="literal"');
+      const [openingTag, closingTag] = getSyntaxHighlightTags('literal');
       return openingTag + code + closingTag;
     }
 
-    const [openingTag, closingTag] = getSpanTags('class="comment"');
+    const [openingTag, closingTag] = getSyntaxHighlightTags('comment');
     if (node.jp instanceof Comment)
       return openingTag + code + closingTag;
     code = code.replaceAll(/(?<!>)(\/\/.*)/g, `${openingTag}$1${closingTag}`);
     code = code.replaceAll(/(?<!>)(\/\*.*?\*\/)/g, `${openingTag}$1${closingTag}`);
 
     if (node.jp instanceof Declarator || node.jp instanceof EnumeratorDecl) {
-      const [openingTag, closingTag] = getSpanTags('class="type"');
+      const [openingTag, closingTag] = getSyntaxHighlightTags('type');
 
       const regex = new RegExp(`\\s*[&*]*\\b${node.jp.name}\\b`);
       const namePos = code.search(regex);
@@ -276,7 +276,7 @@ export default class ClavaAstConverter implements GenericAstConverter {
     }
     
     if (node.jp instanceof Statement || node.jp instanceof Decl) {
-      const [openingTag, closingTag] = getSpanTags('class="keyword"');
+      const [openingTag, closingTag] = getSyntaxHighlightTags('keyword');
 
       if (node.jp instanceof Switch || node.jp instanceof Break || node.jp instanceof Case
         || node.jp instanceof Continue || node.jp instanceof GotoStmt || node.jp instanceof ReturnStmt
@@ -297,7 +297,7 @@ export default class ClavaAstConverter implements GenericAstConverter {
       }
 
       if (node.jp instanceof Loop) {
-        if (node.jp.kind == "dowhile") {
+        if (node.jp.kind == 'dowhile') {
           const whilePos = code.match(/^(([^/]|\/[^/*]|\/\/.*|\/\*([^*]|\*[^/])*\*\/)*?)(?<!>)\bwhile\b/)![1].length;
           return openingTag + 'do' + closingTag + code.slice(2, whilePos) + openingTag + 'while' + closingTag + code.slice(whilePos + 5);
         } else {

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -142,6 +142,7 @@ export default class ClavaAstConverter implements GenericAstConverter {
     return new ToolJoinPoint(
       clavaJp.astId,
       clavaJp.joinPointType,
+      clavaJp.filename,
       this.getJoinPointInfo(clavaJp),
       clavaJp.children.map(child => this.getToolAst(child)),
     );
@@ -235,12 +236,12 @@ export default class ClavaAstConverter implements GenericAstConverter {
     return text.replace(/[&<>]/g, (match) => specialCharMap[match]);
   }
 
-  private getSpanTags(attrs: string[]): string[] {
+  private getSpanTags(...attrs: string[]): string[] {
     return [`<span ${attrs.join(' ')}>`, '</span>'];
   }
 
   private getNodeCodeTags(nodeId: string): string[] {
-    return this.getSpanTags(['class="node-code"', `data-node-id="${nodeId}"`]);
+    return this.getSpanTags('class="node-code"', `data-node-id="${nodeId}"`);
   }
 
   private linkCodeToAstNodes(root: CodeNode, outerCode: string, outerCodeStart: number, outerCodeEnd: number): any[] {

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -1,7 +1,7 @@
 import { LaraJoinPoint } from "lara-js/api/LaraJoinPoint.js";
 import GenericAstConverter from "lara-js/api/visualization/GenericAstConverter.js";
 import ToolJoinPoint from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
-import { Joinpoint } from "../Joinpoints.js";
+import { Body, Joinpoint } from "../Joinpoints.js";
 import Clava from "../clava/Clava.js";
 
 type CodeNode = {
@@ -60,6 +60,13 @@ export default class ClavaAstConverter implements GenericAstConverter {
       this.refineCode(child, newIndentation);
     }
 
+    if (node.jp.joinPointType == 'body' && (node.jp as Body).naked) {
+      const match = node.code.match(/^([^\/]*\S)\s*(\/\/.*)$/);
+      if (match) {
+        const [, statement, comment] = match;
+        node.code = statement + '  ' + comment;
+      }
+    }  // Fix space between statement and inline comment in naked body
     
     if (node.children.length >= 1 && node.children[0].jp.astName === 'TagDeclVars') {
       const tagDeclVars = node.children[0];

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -294,7 +294,7 @@ export default class ClavaAstConverter implements GenericAstConverter {
       }
 
       if (node.jp instanceof If) {
-        const elsePos = code.indexOf('else');
+        const elsePos = code.search(/(?<!(\/\/.*|>))\belse\b/);
         if (elsePos !== -1) {
           return openingTag + 'if' + closingTag + code.slice(2, elsePos) + openingTag + 'else' + closingTag + code.slice(elsePos + 4);
         } else {

--- a/Clava-JS/src-api/visualization/ClavaAstConverter.ts
+++ b/Clava-JS/src-api/visualization/ClavaAstConverter.ts
@@ -1,7 +1,7 @@
 import { LaraJoinPoint } from "lara-js/api/LaraJoinPoint.js";
 import GenericAstConverter, { FilesCode } from "lara-js/api/visualization/GenericAstConverter.js";
 import ToolJoinPoint, { JoinPointInfo } from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
-import { AccessSpecifier, AdjustedType, Body, BoolLiteral, Break, Call, Case, Class, Comment, Continue, Decl, Declarator, DeclStmt, EnumDecl, EnumeratorDecl, Expression, ExprStmt, FileJp, FloatLiteral, FunctionJp, GotoStmt, If, Include, IntLiteral, Joinpoint, Literal, Loop, Marker, NamedDecl, Omp, Pragma, Program, RecordJp, ReturnStmt, Scope, Statement, Switch, Tag, Type, TypedefDecl, Vardecl, Varref, WrapperStmt } from "../Joinpoints.js";
+import { AccessSpecifier, AdjustedType, Body, BoolLiteral, Break, Call, Case, Class, Comment, Continue, Decl, Declarator, DeclStmt, EnumDecl, EnumeratorDecl, ExprStmt, FileJp, FloatLiteral, FunctionJp, GotoStmt, If, Include, IntLiteral, Joinpoint, Literal, Loop, Marker, NamedDecl, Omp, Pragma, Program, RecordJp, ReturnStmt, Scope, Statement, Switch, Tag, Type, TypedefDecl, Vardecl, Varref, WrapperStmt } from "../Joinpoints.js";
 
 type CodeNode = {
   jp: Joinpoint;
@@ -145,7 +145,7 @@ export default class ClavaAstConverter implements GenericAstConverter {
         (nextId++).toString(),
         jp.joinPointType,
         code,
-        jp.filename,
+        jp.filepath,
         this.getJoinPointInfo(jp),
         jp.children.map(child => toToolJoinPoint(child)),
       );
@@ -385,20 +385,20 @@ export default class ClavaAstConverter implements GenericAstConverter {
     if (root instanceof Program) {
       return Object.fromEntries(rootCodeNode.children.map(child => {
         const file = child.children[0];
-        const filename = (file.jp as FileJp).name;
+        const filepath = (file.jp as FileJp).path;
 
         const fileCode = child.code!;  // same as file.code!
         const fileHtmlCode = this.escapeHtml(fileCode);
         const fileLinkedHtmlCode = this.linkCodeToAstNodes(child, fileHtmlCode, 0, fileHtmlCode.length)[2];
-        return [filename, fileLinkedHtmlCode];
+        return [filepath, fileLinkedHtmlCode];
       }));
     } else {
-      const filename = (root as Joinpoint).filename;
+      const filepath = (root as Joinpoint).filepath;
       const code = rootCodeNode.code;
-      const htmlCode = code ? this.escapeHtml(code) : "";
+      const htmlCode = code ? this.escapeHtml(code) : '';
       const linkedHtmlCode = this.linkCodeToAstNodes(rootCodeNode, htmlCode, 0, htmlCode.length)[2];
 
-      return { [filename]: linkedHtmlCode };
+      return { [filepath]: linkedHtmlCode };
     }
   }
 }

--- a/Clava-JS/src-api/visualization/VisualizationTool.ts
+++ b/Clava-JS/src-api/visualization/VisualizationTool.ts
@@ -1,0 +1,18 @@
+import GenericAstConverter from 'lara-js/api/visualization/GenericAstConverter.js';
+import GenericVisualizationTool from 'lara-js/api/visualization/GenericVisualizationTool.js'
+import ClavaAstConverter from './ClavaAstConverter.js';
+
+export class VisualizationTool extends GenericVisualizationTool {
+  private joinPointConverter = new ClavaAstConverter();
+  private static instance: VisualizationTool = new VisualizationTool();
+
+  public static getInstance(): VisualizationTool {
+    return this.instance;
+  }
+
+  protected override getAstConverter(): GenericAstConverter {
+    return this.joinPointConverter;
+  }
+}
+
+export default VisualizationTool.getInstance();

--- a/ClavaLaraApi/src-java/pt/up/fe/specs/clava/weaver/ClavaApiJsResource.java
+++ b/ClavaLaraApi/src-java/pt/up/fe/specs/clava/weaver/ClavaApiJsResource.java
@@ -154,6 +154,8 @@ public enum ClavaApiJsResource implements LaraResourceProvider {
     TIMER_JS("lara/code/Timer.js"),
     ENERGYMETRIC_JS("lara/metrics/EnergyMetric.js"),
     EXECUTIONTIMEMETRIC_JS("lara/metrics/ExecutionTimeMetric.js"),
+    CLAVAASTCONVERTER_JS("visualization/ClavaAstConverter.js"),
+    VISUALIZATIONTOOL_JS("visualization/VisualizationTool.js"),
     WEAVERLAUNCHER_JS("weaver/WeaverLauncher.js");
 
     private final String resource;

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -223,10 +223,11 @@ export default class ClavaAstConverter {
             const [openingTag, closingTag] = this.getSpanTags('class="literal"');
             return openingTag + code + closingTag;
         }
-        if (node.jp instanceof Comment) {
-            const [openingTag, closingTag] = this.getSpanTags('class="comment"');
+        const [openingTag, closingTag] = this.getSpanTags('class="comment"');
+        if (node.jp instanceof Comment)
             return openingTag + code + closingTag;
-        }
+        code = code.replaceAll(/(?<!>)(\/\/.*)/g, `${openingTag}$1${closingTag}`);
+        code = code.replaceAll(/(?<!>)(\/\*.*?\*\/)/g, `${openingTag}$1${closingTag}`);
         if (node.jp instanceof Statement || node.jp instanceof Decl) {
             const [openingTag, closingTag] = this.getSpanTags('class="keyword"');
             if (node.jp instanceof Switch || node.jp instanceof Break || node.jp instanceof Case
@@ -235,7 +236,7 @@ export default class ClavaAstConverter {
                 return code.replace(/^(\w+)(\W.*)$/s, `${openingTag}$1${closingTag}$2`); // Highlight first word
             }
             if (node.jp instanceof If) {
-                const elsePos = code.search(/(?<!(\/\/.*|>))\belse\b/);
+                const elsePos = code.search(/(?<!>)\belse\b/);
                 if (elsePos !== -1) {
                     return openingTag + 'if' + closingTag + code.slice(2, elsePos) + openingTag + 'else' + closingTag + code.slice(elsePos + 4);
                 }
@@ -245,8 +246,7 @@ export default class ClavaAstConverter {
             }
             if (node.jp instanceof Loop) {
                 if (node.jp.kind == "dowhile") {
-                    const loopBodyEndPos = code.indexOf(node.children[0].code) + node.children[0].code.length;
-                    const whilePos = code.indexOf('while', loopBodyEndPos);
+                    const whilePos = code.search(/(?<!>)\while\b/);
                     return openingTag + 'do' + closingTag + code.slice(2, whilePos) + openingTag + 'while' + closingTag + code.slice(whilePos + 5);
                 }
                 else {

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -1,5 +1,5 @@
 import ToolJoinPoint from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
-import { AccessSpecifier, AdjustedType, Body, BoolLiteral, Break, Call, Case, Class, Comment, Continue, Decl, DeclStmt, EnumDecl, ExprStmt, FileJp, FloatLiteral, FunctionJp, GotoStmt, If, Include, IntLiteral, Literal, Loop, NamedDecl, Omp, Pragma, Program, RecordJp, ReturnStmt, Scope, Statement, Switch, Tag, Type, TypedefDecl, Vardecl, Varref, WrapperStmt } from "../Joinpoints.js";
+import { AccessSpecifier, AdjustedType, Body, BoolLiteral, Break, Call, Case, Class, Comment, Continue, Decl, Declarator, DeclStmt, EnumDecl, EnumeratorDecl, ExprStmt, FileJp, FloatLiteral, FunctionJp, GotoStmt, If, Include, IntLiteral, Literal, Loop, NamedDecl, Omp, Pragma, Program, RecordJp, ReturnStmt, Scope, Statement, Switch, Tag, Type, TypedefDecl, Vardecl, Varref, WrapperStmt } from "../Joinpoints.js";
 export default class ClavaAstConverter {
     getJoinPointInfo(jp) {
         const info = {
@@ -228,12 +228,19 @@ export default class ClavaAstConverter {
             return openingTag + code + closingTag;
         code = code.replaceAll(/(?<!>)(\/\/.*)/g, `${openingTag}$1${closingTag}`);
         code = code.replaceAll(/(?<!>)(\/\*.*?\*\/)/g, `${openingTag}$1${closingTag}`);
+        if (node.jp instanceof Declarator || node.jp instanceof EnumeratorDecl) {
+            const [openingTag, closingTag] = this.getSpanTags('class="type"');
+            const regex = new RegExp(`\\s*[&*]*${node.jp.name}\\b`);
+            const namePos = code.search(regex);
+            return namePos <= 0 ? code : openingTag + code.slice(0, namePos) + closingTag + code.slice(namePos);
+        }
         if (node.jp instanceof Statement || node.jp instanceof Decl) {
             const [openingTag, closingTag] = this.getSpanTags('class="keyword"');
             if (node.jp instanceof Switch || node.jp instanceof Break || node.jp instanceof Case
                 || node.jp instanceof Continue || node.jp instanceof GotoStmt || node.jp instanceof ReturnStmt
-                || node.jp instanceof EnumDecl || node.jp instanceof AccessSpecifier) {
-                return code.replace(/^(\w+)(\W.*)$/s, `${openingTag}$1${closingTag}$2`); // Highlight first word
+                || node.jp instanceof EnumDecl || node.jp instanceof AccessSpecifier
+                || node.jp.astName == "FunctionTemplateDecl" || node.jp.astName == "TemplateTypeParmDecl") {
+                return code.replace(/^(\w+)(?=\W)/s, `${openingTag}$1${closingTag}`); // Highlight first word
             }
             if (node.jp instanceof If) {
                 const elsePos = code.search(/(?<!>)\belse\b/);
@@ -250,17 +257,17 @@ export default class ClavaAstConverter {
                     return openingTag + 'do' + closingTag + code.slice(2, whilePos) + openingTag + 'while' + closingTag + code.slice(whilePos + 5);
                 }
                 else {
-                    return code.replace(/^(\w+)(\W.*)$/s, `${openingTag}$1${closingTag}$2`); // Highlight first word
+                    return code.replace(/^(\w+)(?=\W)/s, `${openingTag}$1${closingTag}`); // Highlight first word
                 }
             }
-            if (node.jp instanceof TypedefDecl && node.code.startsWith('typedef')) {
+            if (node.jp instanceof TypedefDecl && node.code.startsWith('typedef')) { // The code of a TypedefDecl can be divided, and the second part does not have the keyword
                 return openingTag + 'typedef' + closingTag + code.slice(7);
             }
             if (node.jp instanceof RecordJp) {
                 return code.replace(/^(.*?)(class(?!=)|struct)(.*)$/s, `$1${openingTag}$2${closingTag}$3`); // Highlight 'class' or 'struct' in declaration
             }
             if (node.jp instanceof Include || node.jp instanceof Pragma) {
-                return code.replace(/^(#\w+)(\W.*)$/s, `${openingTag}$1${closingTag}$2`);
+                return code.replace(/^(#\w+)(?=\W)/s, `${openingTag}$1${closingTag}`);
             }
         }
         return code;

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -1,9 +1,22 @@
 import ToolJoinPoint from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
 import Clava from "../clava/Clava.js";
 export default class ClavaAstConverter {
+    getJoinPointInfo(jp) {
+        const info = {
+            'astId': jp.astId,
+            'astName': jp.astName,
+        };
+        switch (jp.joinPointType) {
+            case 'intLiteral':
+                const intLiteral = jp;
+                info['value'] = intLiteral.value.toString();
+                break;
+        }
+        return info;
+    }
     getToolAst(root) {
         const clavaJp = root;
-        return new ToolJoinPoint(clavaJp.astId, clavaJp.joinPointType, {}, clavaJp.children.map(child => this.getToolAst(child)));
+        return new ToolJoinPoint(clavaJp.astId, clavaJp.joinPointType, this.getJoinPointInfo(clavaJp), clavaJp.children.map(child => this.getToolAst(child)));
     }
     toCodeNode(jp) {
         return {

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -3,7 +3,7 @@ import Clava from "../clava/Clava.js";
 export default class ClavaAstConverter {
     getToolAst(root) {
         const clavaJp = root;
-        return new ToolJoinPoint(clavaJp.astId, clavaJp.joinPointType, clavaJp.code, clavaJp.children.map(child => this.getToolAst(child)));
+        return new ToolJoinPoint(clavaJp.astId, clavaJp.joinPointType, clavaJp.children.map(child => this.getToolAst(child)));
     }
     toCodeMap(jp, codeMap) {
         codeMap[jp.astId] = jp.code.trim();

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -2,10 +2,20 @@ import ToolJoinPoint from "lara-js/api/visualization/public/js/ToolJoinPoint.js"
 import { AccessSpecifier, AdjustedType, Body, BoolLiteral, Break, Call, Case, Class, Comment, Continue, Decl, Declarator, DeclStmt, EnumDecl, EnumeratorDecl, ExprStmt, FileJp, FloatLiteral, FunctionJp, GotoStmt, If, Include, IntLiteral, Literal, Loop, NamedDecl, Omp, Pragma, Program, RecordJp, ReturnStmt, Scope, Statement, Switch, Tag, Type, TypedefDecl, Vardecl, Varref, WrapperStmt } from "../Joinpoints.js";
 import Clava from "../clava/Clava.js";
 import { addIdentation, escapeHtml, getNodeCodeTags, getSyntaxHighlightTags } from "lara-js/api/visualization/AstConverterUtils.js";
+/**
+ * @brief Clava specialization of GenericAstConverter.
+ */
 export default class ClavaAstConverter {
     updateAst() {
         Clava.rebuild();
     }
+    /**
+     * @brief Returns the code of the given node.
+     * @details If the node has no code, returns undefined, instead of raising an error.
+     *
+     * @param node Node
+     * @returns The code of the node, or undefined if it has no code
+     */
     getCode(node) {
         // TODO: When hasCode implementation is ready, replace this body with the following line:
         // return node.hasCode ? node.code.trim() : undefined
@@ -19,6 +29,12 @@ export default class ClavaAstConverter {
         }
         return code;
     }
+    /**
+     * @brief Returns the information of the given join point, according to its type.
+     *
+     * @param jp Join point
+     * @returns The information of the join point
+     */
     getJoinPointInfo(jp) {
         const info = {
             'AST ID': jp.astId,
@@ -65,6 +81,7 @@ export default class ClavaAstConverter {
                 'Constant?': jp.constant,
                 'Is builtin': jp.isBuiltin,
                 'Has sugar': jp.hasSugar,
+                'Type kind': jp.kind
             });
         }
         if (jp instanceof Varref) {
@@ -126,6 +143,14 @@ export default class ClavaAstConverter {
         };
         return toToolJoinPoint(root);
     }
+    /**
+     * @brief Converts the given join point to a CodeNode.
+     * @details This function assigns ids to the nodes in pre-order, and it MUST
+     * be the same as the order used for getToolAst.
+     *
+     * @param jp Join point
+     * @returns The CodeNode representation of the join point
+     */
     toCodeNode(jp) {
         let nextId = 0;
         const toCodeNode = (jp) => {
@@ -138,6 +163,15 @@ export default class ClavaAstConverter {
         };
         return toCodeNode(jp);
     }
+    /**
+     * @brief Sorts the given code nodes by location.
+     * @details This function uses the join points' line and column, instead of
+     * location attribute. If a node does not have a location (line and code),
+     * it is placed before all the others.
+     *
+     * @param codeNodes Array of code nodes
+     * @returns Reference to the original (sorted) array
+     */
     sortByLocation(codeNodes) {
         return codeNodes.sort((node1, node2) => {
             if (node1.jp.line === node2.jp.line)
@@ -145,6 +179,17 @@ export default class ClavaAstConverter {
             return (node1.jp.line ?? -1) - (node2.jp.line ?? -1);
         });
     }
+    /**
+     * @brief Applies refinements and corrections to the node code and order of
+     * the children.
+     * @details This is necessary because some nodes do not have its designated
+     * code equal to the matching code in the container. For example, the code
+     * inside code blocks do not have its indentation.
+     *
+     * @param node The node code
+     * @param indentation The current indentation to use
+     * @returns Reference to the original (refined) node
+     */
     refineCode(node, indentation = 0) {
         if (node.code)
             node.code = addIdentation(node.code, indentation);
@@ -158,8 +203,8 @@ export default class ClavaAstConverter {
             node.children
                 .slice(1)
                 .forEach(child => {
-                child.code = child.code.match(/^(?:\S+\s+)(\S.*)$/)[1];
-            }); // Remove type from variable declarations
+                child.code = child.code.match(/^(?:\S+\s+)(\S.*)$/)[1]; // Remove type from variable declarations
+            });
         }
         for (const child of node.children) {
             const newIndentation = (node.jp instanceof Scope || node.jp instanceof Class) ? indentation + 1 : indentation;
@@ -169,9 +214,9 @@ export default class ClavaAstConverter {
             const match = node.code.match(/^([^\/]*\S)\s*(\/\/.*)$/);
             if (match) {
                 const [, statement, comment] = match;
-                node.code = statement + '  ' + comment;
+                node.code = statement + '  ' + comment; // Fix space between statement and inline comment in naked body
             }
-        } // Fix space between statement and inline comment in naked body
+        }
         if (node.children.length >= 1 && node.children[0].jp.astName === 'TagDeclVars') {
             const tagDeclVars = node.children[0];
             const typedef = tagDeclVars.children[0];
@@ -197,6 +242,16 @@ export default class ClavaAstConverter {
         } // Divide program code into its files
         return node;
     }
+    /**
+     * @brief Performs C/C++ syntax hioverlighting on the given code.
+     * @details This is done by inserting the appropriate span tags around the
+     * code to be highlighted, using the HTML code as a string
+     *
+     * @param code The code to be highlighted, with the code of its children
+     * already linked and syntax highlighted
+     * @param node The node that the code belongs to
+     * @returns The syntax highlighted code
+     */
     syntaxHighlight(code, node) {
         if (code === undefined)
             return undefined;
@@ -211,11 +266,12 @@ export default class ClavaAstConverter {
         const [openingTag, closingTag] = getSyntaxHighlightTags('comment');
         if (node.jp instanceof Comment)
             return openingTag + code + closingTag;
-        code = code.replaceAll(/(?<!>)(\/\/.*)/g, `${openingTag}$1${closingTag}`);
-        code = code.replaceAll(/(?<!>)(\/\*.*?\*\/)/g, `${openingTag}$1${closingTag}`);
+        code = code.replaceAll(/(?<!>)(\/\/.*)/g, `${openingTag}$1${closingTag}`); // Highlight unhighlighted single-line comments
+        code = code.replaceAll(/(?<!>)(\/\*.*?\*\/)/g, `${openingTag}$1${closingTag}`); // Highlight unhighlighted multi-line comments
+        // We know that a piece of code is not highlighted if it is not preceded by a '>' (from the opening span tag)
         if (node.jp instanceof Declarator || node.jp instanceof EnumeratorDecl) {
             const [openingTag, closingTag] = getSyntaxHighlightTags('type');
-            const regex = new RegExp(`\\s*[&*]*\\b${node.jp.name}\\b`);
+            const regex = new RegExp(`\\s*[&*]*\\b${node.jp.name}\\b`); // Match the declaration name with the '&' and '*' prefixes
             const namePos = code.search(regex);
             return namePos <= 0 ? code : openingTag + code.slice(0, namePos) + closingTag + code.slice(namePos);
         }
@@ -228,7 +284,8 @@ export default class ClavaAstConverter {
                 return code.replace(/^(\w+)\b/, `${openingTag}$1${closingTag}`); // Highlight first word
             }
             if (node.jp instanceof If) {
-                const elseMatch = code.match(/^(([^/]|\/[^/*]|\/\/.*|\/\*([^*]|\*[^/])*\*\/)*?)(?<!>)\belse\b/);
+                const elseMatch = code.match(/^(([^/]|\/[^/*]|\/\/.*|\/\*([^*]|\*[^/])*\*\/)*?)(?<!>)\belse\b/); // Match first unhighlighted 'else' that is not inside a comment (single or multi-line)
+                // Note that the function is meant to be called recursively, so the 'else' of child ifs are already highlighted
                 if (elseMatch) {
                     const elsePos = elseMatch[1].length;
                     return openingTag + 'if' + closingTag + code.slice(2, elsePos) + openingTag + 'else' + closingTag + code.slice(elsePos + 4);
@@ -239,7 +296,8 @@ export default class ClavaAstConverter {
             }
             if (node.jp instanceof Loop) {
                 if (node.jp.kind == 'dowhile') {
-                    const whilePos = code.match(/^(([^/]|\/[^/*]|\/\/.*|\/\*([^*]|\*[^/])*\*\/)*?)(?<!>)\bwhile\b/)[1].length;
+                    const whilePos = code.match(/^(([^/]|\/[^/*]|\/\/.*|\/\*([^*]|\*[^/])*\*\/)*?)(?<!>)\bwhile\b/)[1].length; // Match first unhighlighted 'while' that is not inside a comment (single or multi-line)
+                    // Same logic as the 'else' keyword
                     return openingTag + 'do' + closingTag + code.slice(2, whilePos) + openingTag + 'while' + closingTag + code.slice(whilePos + 5);
                 }
                 else {
@@ -253,21 +311,33 @@ export default class ClavaAstConverter {
                 return code.replace(/(class(?!=)|struct)/, `${openingTag}$1${closingTag}`); // Highlight 'class' or 'struct' in declaration
             }
             if (node.jp instanceof Include || node.jp instanceof Pragma) {
-                return code.replace(/^(#\w+)\b/, `${openingTag}$1${closingTag}`);
+                return code.replace(/^(#\w+)\b/, `${openingTag}$1${closingTag}`); // Highlight the directive
             }
         }
         return code;
     }
+    /**
+     * @brief Links the nodes of the given AST to their respective portion of code.
+     *
+     * @param root The root node of the AST
+     * @param outerCode The outer code, which should contain the code of all the
+     * nodes
+     * @param outerCodeStart The start index of the outer code section to be used
+     * @param outerCodeEnd The end index of the outer code section to be used
+     * @returns Array with three elements: the start index of the node code in the
+     * outer code, the end index of the node code in the outer code, and the
+     * linked code.
+     */
     linkCodeToAstNodes(root, outerCode, outerCodeStart, outerCodeEnd) {
         const nodeCode = root.code;
         if (!nodeCode || !outerCode)
-            return [outerCodeStart, outerCodeStart, ""];
+            return [outerCodeStart, outerCodeStart, ""]; // Return empty string if the node has no code
         const nodeCodeHtml = escapeHtml(nodeCode);
         const innerCodeStart = outerCode.indexOf(nodeCodeHtml, outerCodeStart);
         const innerCodeEnd = innerCodeStart + nodeCodeHtml.length;
         if (innerCodeStart === -1 || innerCodeEnd > outerCodeEnd) {
             console.warn(`Code of node "${root.jp.joinPointType}" not found in code container: "${nodeCodeHtml}"`);
-            return [outerCodeStart, outerCodeStart, ""];
+            return [outerCodeStart, outerCodeStart, ""]; // Return empty string if the node code is not found
         }
         const [openingTag, closingTag] = getNodeCodeTags(root.id);
         let newCode = '';
@@ -282,10 +352,10 @@ export default class ClavaAstConverter {
         } // Ignore function return type and name in declaration
         for (const child of root.children) {
             const [childCodeStart, childCodeEnd, childCode] = this.linkCodeToAstNodes(child, outerCode, newCodeIndex, innerCodeEnd);
-            newCode += outerCode.slice(newCodeIndex, childCodeStart) + childCode;
+            newCode += outerCode.slice(newCodeIndex, childCodeStart) + childCode; // Add portion behind children that is not matched and the linked child code
             newCodeIndex = childCodeEnd;
         }
-        newCode += outerCode.slice(newCodeIndex, innerCodeEnd);
+        newCode += outerCode.slice(newCodeIndex, innerCodeEnd); // Add the remaining unmatched code
         newCode = this.syntaxHighlight(newCode, root);
         return [innerCodeStart, innerCodeEnd, openingTag + newCode + closingTag];
     }

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -3,10 +3,7 @@ import Clava from "../clava/Clava.js";
 export default class ClavaAstConverter {
     getToolAst(root) {
         const clavaJp = root;
-        return new ToolJoinPoint(clavaJp.astId, clavaJp.joinPointType, clavaJp.children.map(child => this.getToolAst(child)));
-    }
-    sortByLocation(codeNodes) {
-        return codeNodes.sort((node1, node2) => node1.jp.location.localeCompare(node2.jp.location, 'en', { numeric: true }));
+        return new ToolJoinPoint(clavaJp.astId, clavaJp.joinPointType, {}, clavaJp.children.map(child => this.getToolAst(child)));
     }
     toCodeNode(jp) {
         return {
@@ -17,6 +14,9 @@ export default class ClavaAstConverter {
     }
     addIdentation(code, indentation) {
         return code.split('\n').map((line, i) => i > 0 ? '   '.repeat(indentation) + line : line).join('\n');
+    }
+    sortByLocation(codeNodes) {
+        return codeNodes.sort((node1, node2) => node1.jp.location.localeCompare(node2.jp.location, 'en', { numeric: true }));
     }
     refineCode(node, indentation = 0) {
         node.code = this.addIdentation(node.code, indentation);

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -235,7 +235,7 @@ export default class ClavaAstConverter {
                 return code.replace(/^(\w+)(\W.*)$/s, `${openingTag}$1${closingTag}$2`); // Highlight first word
             }
             if (node.jp instanceof If) {
-                const elsePos = code.indexOf('else');
+                const elsePos = code.search(/(?<!(\/\/.*|>))\belse\b/);
                 if (elsePos !== -1) {
                     return openingTag + 'if' + closingTag + code.slice(2, elsePos) + openingTag + 'else' + closingTag + code.slice(elsePos + 4);
                 }

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -240,7 +240,7 @@ export default class ClavaAstConverter {
                 || node.jp instanceof Continue || node.jp instanceof GotoStmt || node.jp instanceof ReturnStmt
                 || node.jp instanceof EnumDecl || node.jp instanceof AccessSpecifier
                 || node.jp.astName == "FunctionTemplateDecl" || node.jp.astName == "TemplateTypeParmDecl") {
-                return code.replace(/^(\w+)\b/s, `${openingTag}$1${closingTag}`); // Highlight first word
+                return code.replace(/^(\w+)\b/, `${openingTag}$1${closingTag}`); // Highlight first word
             }
             if (node.jp instanceof If) {
                 const elseMatch = code.match(/^(([^/]|\/[^/*]|\/\/.*|\/\*([^*]|\*[^/])*\*\/)*?)(?<!>)\belse\b/);
@@ -258,17 +258,17 @@ export default class ClavaAstConverter {
                     return openingTag + 'do' + closingTag + code.slice(2, whilePos) + openingTag + 'while' + closingTag + code.slice(whilePos + 5);
                 }
                 else {
-                    return code.replace(/^(\w+)(?=\W)/s, `${openingTag}$1${closingTag}`); // Highlight first word
+                    return code.replace(/^(\w+)\b/, `${openingTag}$1${closingTag}`); // Highlight first word
                 }
             }
             if (node.jp instanceof TypedefDecl && node.code.startsWith('typedef')) { // The code of a TypedefDecl can be divided, and the second part does not have the keyword
                 return openingTag + 'typedef' + closingTag + code.slice(7);
             }
             if (node.jp instanceof RecordJp) {
-                return code.replace(/(class(?!=)|struct)/s, `$1${openingTag}$2${closingTag}$3`); // Highlight 'class' or 'struct' in declaration
+                return code.replace(/(class(?!=)|struct)/, `${openingTag}$1${closingTag}`); // Highlight 'class' or 'struct' in declaration
             }
             if (node.jp instanceof Include || node.jp instanceof Pragma) {
-                return code.replace(/^(#\w+)\b/s, `${openingTag}$1${closingTag}`);
+                return code.replace(/^(#\w+)\b/, `${openingTag}$1${closingTag}`);
             }
         }
         return code;

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -310,7 +310,8 @@ export default class ClavaAstConverter {
         if (root instanceof Program) {
             return Object.fromEntries(rootCodeNode.children.map(child => {
                 const file = child.children[0];
-                const filepath = file.jp.path;
+                const fileJp = file.jp;
+                const filepath = fileJp.filepath;
                 const fileCode = child.code; // same as file.code!
                 const fileHtmlCode = this.escapeHtml(fileCode);
                 const fileLinkedHtmlCode = this.linkCodeToAstNodes(child, fileHtmlCode, 0, fileHtmlCode.length)[2];

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -1,6 +1,5 @@
 import ToolJoinPoint from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
 import { AdjustedType, BoolLiteral, Call, Class, FileJp, FloatLiteral, Include, IntLiteral, Loop, Marker, NamedDecl, Omp, Pragma, Program, Tag, Type, TypedefDecl, Varref, WrapperStmt } from "../Joinpoints.js";
-import Clava from "../clava/Clava.js";
 export default class ClavaAstConverter {
     getJoinPointInfo(jp) {
         const info = {
@@ -209,8 +208,7 @@ export default class ClavaAstConverter {
         newCode += outerCode.slice(newCodeIndex, innerCodeEnd) + closingTag;
         return [innerCodeStart, innerCodeEnd, newCode];
     }
-    getPrettyHtmlCode() {
-        const root = Clava.getProgram();
+    getPrettyHtmlCode(root) {
         const rootCodeNode = this.toCodeNode(root);
         this.refineCode(rootCodeNode);
         let code = rootCodeNode.code;

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -1,13 +1,13 @@
 import ToolJoinPoint from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
 import { AccessSpecifier, AdjustedType, Body, BoolLiteral, Break, Call, Case, Class, Comment, Continue, Decl, Declarator, DeclStmt, EnumDecl, EnumeratorDecl, ExprStmt, FileJp, FloatLiteral, FunctionJp, GotoStmt, If, Include, IntLiteral, Literal, Loop, NamedDecl, Omp, Pragma, Program, RecordJp, ReturnStmt, Scope, Statement, Switch, Tag, Type, TypedefDecl, Vardecl, Varref, WrapperStmt } from "../Joinpoints.js";
 import Clava from "../clava/Clava.js";
-import { addIdentation, escapeHtml, getNodeCodeTags, getSpanTags } from "lara-js/api/visualization/AstConverterUtils.js";
+import { addIdentation, escapeHtml, getNodeCodeTags, getSyntaxHighlightTags } from "lara-js/api/visualization/AstConverterUtils.js";
 export default class ClavaAstConverter {
     updateAst() {
         Clava.rebuild();
     }
     getCode(node) {
-        // When hasCode implementation is ready, replace this method with the following line:
+        // TODO: When hasCode implementation is ready, replace this body with the following line:
         // return node.hasCode ? node.code.trim() : undefined
         let code;
         try {
@@ -201,26 +201,26 @@ export default class ClavaAstConverter {
         if (code === undefined)
             return undefined;
         if (node.jp.astName === "StringLiteral") {
-            const [openingTag, closingTag] = getSpanTags('class="string"');
+            const [openingTag, closingTag] = getSyntaxHighlightTags('string');
             return openingTag + code + closingTag;
         }
         if (node.jp instanceof Literal) {
-            const [openingTag, closingTag] = getSpanTags('class="literal"');
+            const [openingTag, closingTag] = getSyntaxHighlightTags('literal');
             return openingTag + code + closingTag;
         }
-        const [openingTag, closingTag] = getSpanTags('class="comment"');
+        const [openingTag, closingTag] = getSyntaxHighlightTags('comment');
         if (node.jp instanceof Comment)
             return openingTag + code + closingTag;
         code = code.replaceAll(/(?<!>)(\/\/.*)/g, `${openingTag}$1${closingTag}`);
         code = code.replaceAll(/(?<!>)(\/\*.*?\*\/)/g, `${openingTag}$1${closingTag}`);
         if (node.jp instanceof Declarator || node.jp instanceof EnumeratorDecl) {
-            const [openingTag, closingTag] = getSpanTags('class="type"');
+            const [openingTag, closingTag] = getSyntaxHighlightTags('type');
             const regex = new RegExp(`\\s*[&*]*\\b${node.jp.name}\\b`);
             const namePos = code.search(regex);
             return namePos <= 0 ? code : openingTag + code.slice(0, namePos) + closingTag + code.slice(namePos);
         }
         if (node.jp instanceof Statement || node.jp instanceof Decl) {
-            const [openingTag, closingTag] = getSpanTags('class="keyword"');
+            const [openingTag, closingTag] = getSyntaxHighlightTags('keyword');
             if (node.jp instanceof Switch || node.jp instanceof Break || node.jp instanceof Case
                 || node.jp instanceof Continue || node.jp instanceof GotoStmt || node.jp instanceof ReturnStmt
                 || node.jp instanceof EnumDecl || node.jp instanceof AccessSpecifier
@@ -238,7 +238,7 @@ export default class ClavaAstConverter {
                 }
             }
             if (node.jp instanceof Loop) {
-                if (node.jp.kind == "dowhile") {
+                if (node.jp.kind == 'dowhile') {
                     const whilePos = code.match(/^(([^/]|\/[^/*]|\/\/.*|\/\*([^*]|\*[^/])*\*\/)*?)(?<!>)\bwhile\b/)[1].length;
                     return openingTag + 'do' + closingTag + code.slice(2, whilePos) + openingTag + 'while' + closingTag + code.slice(whilePos + 5);
                 }

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -1,0 +1,20 @@
+import ToolJoinPoint from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
+export default class ClavaAstConverter {
+    sortByLocation(jps) {
+        return jps.sort((jp1, jp2) => jp1.location.localeCompare(jp2.location, 'en', { numeric: true }));
+    }
+    toToolJoinPoint(jp) {
+        const clavaJp = jp;
+        const sortedChildren = this.sortByLocation(clavaJp.children.slice());
+        return new ToolJoinPoint(clavaJp.astId, clavaJp.joinPointType, clavaJp.code, sortedChildren.map(child => this.toToolJoinPoint(child)));
+    }
+    refineJoinPoint(jp) {
+    }
+    getToolAst(root) {
+        return this.toToolJoinPoint(root);
+    }
+    getPrettyHtmlCode() {
+        return '';
+    }
+}
+//# sourceMappingURL=ClavaAstConverter.js.map

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -214,10 +214,23 @@ export default class ClavaAstConverter {
     getPrettyHtmlCode(root) {
         const rootCodeNode = this.toCodeNode(root);
         this.refineCode(rootCodeNode);
-        let code = rootCodeNode.children[0].code;
-        code = this.escapeHtml(code);
-        code = this.linkCodeToAstNodes(rootCodeNode.children[0], code, 0, code.length)[2];
-        return { "": code };
+        if (root instanceof Program) {
+            return Object.fromEntries(rootCodeNode.children.map(child => {
+                const file = child.children[0];
+                const filename = file.jp.name;
+                const fileCode = child.code; // same as file.code
+                const fileHtmlCode = this.escapeHtml(fileCode);
+                const fileLinkedHtmlCode = this.linkCodeToAstNodes(child, fileHtmlCode, 0, fileHtmlCode.length)[2];
+                return [filename, fileLinkedHtmlCode];
+            }));
+        }
+        else {
+            const filename = root.filename;
+            const code = rootCodeNode.code;
+            const htmlCode = this.escapeHtml(code);
+            const linkedHtmlCode = this.linkCodeToAstNodes(rootCodeNode, htmlCode, 0, htmlCode.length)[2];
+            return { [filename]: linkedHtmlCode };
+        }
     }
 }
 //# sourceMappingURL=ClavaAstConverter.js.map

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -112,7 +112,7 @@ export default class ClavaAstConverter {
                 console.error(`Could not get code of node '${jp.joinPointType}': ${e}`);
                 code = undefined;
             }
-            return new ToolJoinPoint((nextId++).toString(), jp.joinPointType, code ?? '', jp.filename, this.getJoinPointInfo(jp), jp.children.map(child => toToolJoinPoint(child)));
+            return new ToolJoinPoint((nextId++).toString(), jp.joinPointType, code, jp.filepath, this.getJoinPointInfo(jp), jp.children.map(child => toToolJoinPoint(child)));
         };
         return toToolJoinPoint(root);
     }
@@ -310,19 +310,19 @@ export default class ClavaAstConverter {
         if (root instanceof Program) {
             return Object.fromEntries(rootCodeNode.children.map(child => {
                 const file = child.children[0];
-                const filename = file.jp.name;
+                const filepath = file.jp.path;
                 const fileCode = child.code; // same as file.code!
                 const fileHtmlCode = this.escapeHtml(fileCode);
                 const fileLinkedHtmlCode = this.linkCodeToAstNodes(child, fileHtmlCode, 0, fileHtmlCode.length)[2];
-                return [filename, fileLinkedHtmlCode];
+                return [filepath, fileLinkedHtmlCode];
             }));
         }
         else {
-            const filename = root.filename;
+            const filepath = root.filepath;
             const code = rootCodeNode.code;
-            const htmlCode = code ? this.escapeHtml(code) : "";
+            const htmlCode = code ? this.escapeHtml(code) : '';
             const linkedHtmlCode = this.linkCodeToAstNodes(rootCodeNode, htmlCode, 0, htmlCode.length)[2];
-            return { [filename]: linkedHtmlCode };
+            return { [filepath]: linkedHtmlCode };
         }
     }
 }

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -109,7 +109,7 @@ export default class ClavaAstConverter {
     }
     getToolAst(root) {
         const clavaJp = root;
-        return new ToolJoinPoint(clavaJp.astId, clavaJp.joinPointType, this.getJoinPointInfo(clavaJp), clavaJp.children.map(child => this.getToolAst(child)));
+        return new ToolJoinPoint(clavaJp.astId, clavaJp.joinPointType, clavaJp.filename, this.getJoinPointInfo(clavaJp), clavaJp.children.map(child => this.getToolAst(child)));
     }
     toCodeNode(jp) {
         return {
@@ -185,11 +185,11 @@ export default class ClavaAstConverter {
         };
         return text.replace(/[&<>]/g, (match) => specialCharMap[match]);
     }
-    getSpanTags(attrs) {
+    getSpanTags(...attrs) {
         return [`<span ${attrs.join(' ')}>`, '</span>'];
     }
     getNodeCodeTags(nodeId) {
-        return this.getSpanTags(['class="node-code"', `data-node-id="${nodeId}"`]);
+        return this.getSpanTags('class="node-code"', `data-node-id="${nodeId}"`);
     }
     linkCodeToAstNodes(root, outerCode, outerCodeStart, outerCodeEnd) {
         const nodeCode = root.code;

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -104,7 +104,15 @@ export default class ClavaAstConverter {
     getToolAst(root) {
         let nextId = 0;
         const toToolJoinPoint = (jp) => {
-            return new ToolJoinPoint((nextId++).toString(), jp.joinPointType, jp.filename, this.getJoinPointInfo(jp), jp.children.map(child => toToolJoinPoint(child)));
+            let code;
+            try {
+                code = jp.code.trim();
+            }
+            catch (e) {
+                console.error(`Could not get code of node '${jp.joinPointType}': ${e}`);
+                code = undefined;
+            }
+            return new ToolJoinPoint((nextId++).toString(), jp.joinPointType, code ?? '', jp.filename, this.getJoinPointInfo(jp), jp.children.map(child => toToolJoinPoint(child)));
         };
         return toToolJoinPoint(root);
     }

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -1,41 +1,88 @@
 import ToolJoinPoint from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
+import Clava from "../clava/Clava.js";
 export default class ClavaAstConverter {
-    sortByLocation(jps) {
-        return jps.sort((jp1, jp2) => jp1.location.localeCompare(jp2.location, 'en', { numeric: true }));
+    getToolAst(root) {
+        const clavaJp = root;
+        return new ToolJoinPoint(clavaJp.astId, clavaJp.joinPointType, clavaJp.code, clavaJp.children.map(child => this.getToolAst(child)));
     }
-    toToolJoinPoint(jp) {
-        const clavaJp = jp;
-        const sortedChildren = this.sortByLocation(clavaJp.children.slice());
-        return new ToolJoinPoint(clavaJp.astId, clavaJp.joinPointType, clavaJp.code, sortedChildren.map(child => this.toToolJoinPoint(child)));
+    toCodeMap(jp, codeMap) {
+        codeMap[jp.astId] = jp.code.trim();
+        jp.children.forEach(child => this.toCodeMap(child, codeMap));
+        return codeMap;
     }
     addIdentation(code, indentation) {
         return code.split('\n').map((line, i) => i > 0 ? '   '.repeat(indentation) + line : line).join('\n');
     }
-    refineAstCode(root, indentation = 0) {
-        root.code = this.addIdentation(root.code.trim(), indentation);
-        const children = root.children;
-        if (root.type == 'loop') {
-            children
-                .filter(child => child.type === 'exprStmt')
-                .forEach(child => child.code = child.code.slice(0, -1)); // Remove semicolon from expression statements inside loop parentheses
+    refineCodeMap(root, codeMap, indentation = 0) {
+        codeMap[root.astId] = this.addIdentation(codeMap[root.astId], indentation);
+        if (root.joinPointType == 'loop') {
+            root.children
+                .filter(child => child.joinPointType === 'exprStmt')
+                .forEach(child => codeMap[child.astId] = codeMap[child.astId].slice(0, -1)); // Remove semicolon from expression statements inside loop parentheses
         }
-        if (root.type == 'declStmt') {
+        if (root.joinPointType == 'declStmt') {
             root.children
                 .slice(1)
                 .forEach(child => {
-                child.code = child.code.match(/(?:\S+\s+)(\S.*)/)[1];
+                codeMap[child.astId] = codeMap[child.astId].match(/(?:\S+\s+)(\S.*)/)[1];
             }); // Remove type from variable declarations
         }
         for (const child of root.children) {
-            this.refineAstCode(child, ['body', 'class'].includes(root.type) ? indentation + 1 : indentation);
+            const newIndentation = ['body', 'class'].includes(root.joinPointType) ? indentation + 1 : indentation;
+            this.refineCodeMap(child, codeMap, newIndentation);
         }
-        return root;
+        return codeMap;
     }
-    getToolAst(root) {
-        return this.refineAstCode(this.toToolJoinPoint(root));
+    escapeHtml(text) {
+        const specialCharMap = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+        };
+        return text.replace(/[&<>]/g, (match) => specialCharMap[match]);
+    }
+    getSpanTags(attrs) {
+        return [`<span ${attrs.join(' ')}>`, '</span>'];
+    }
+    getNodeCodeTags(nodeId) {
+        return this.getSpanTags(['class="node-code"', `data-node-id="${nodeId}"`]);
+    }
+    sortByLocation(jps) {
+        return jps.sort((jp1, jp2) => jp1.location.localeCompare(jp2.location, 'en', { numeric: true }));
+    }
+    linkCodeToAstNodes(root, codeMap, outerCode, outerCodeStart, outerCodeEnd) {
+        const nodeCode = codeMap[root.astId];
+        const nodeCodeHtml = this.escapeHtml(nodeCode);
+        const innerCodeStart = outerCode.indexOf(nodeCodeHtml, outerCodeStart);
+        const innerCodeEnd = innerCodeStart + nodeCodeHtml.length;
+        if (innerCodeStart === -1 || innerCodeEnd > outerCodeEnd) {
+            console.warn(`Code of node "${root.joinPointType}" not found in code container: "${nodeCodeHtml}"`);
+            return [outerCodeStart, outerCodeStart, ""];
+        }
+        if (root.joinPointType === 'varref' && nodeCode === 'i') {
+            console.warn(outerCode.slice(outerCodeStart, outerCodeEnd), innerCodeStart);
+        }
+        const [openingTag, closingTag] = this.getNodeCodeTags(root.astId);
+        let newCode = openingTag;
+        let newCodeIndex = innerCodeStart;
+        const sortedChildren = this.sortByLocation(root.children.slice());
+        for (const child of sortedChildren) {
+            const [childCodeStart, childCodeEnd, childCode] = this.linkCodeToAstNodes(child, codeMap, outerCode, newCodeIndex, innerCodeEnd);
+            newCode += outerCode.slice(newCodeIndex, childCodeStart) + childCode;
+            newCodeIndex = childCodeEnd;
+        }
+        newCode += outerCode.slice(newCodeIndex, innerCodeEnd) + closingTag;
+        return [innerCodeStart, innerCodeEnd, newCode];
     }
     getPrettyHtmlCode() {
-        return '';
+        const root = Clava.getProgram();
+        const codeMap = {};
+        this.toCodeMap(root, codeMap);
+        this.refineCodeMap(root, codeMap);
+        let code = codeMap[root.astId];
+        code = this.escapeHtml(code);
+        code = this.linkCodeToAstNodes(root, codeMap, code, 0, code.length)[2];
+        return code;
     }
 }
 //# sourceMappingURL=ClavaAstConverter.js.map

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -1,6 +1,10 @@
 import ToolJoinPoint from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
 import { AccessSpecifier, AdjustedType, Body, BoolLiteral, Break, Call, Case, Class, Comment, Continue, Decl, Declarator, DeclStmt, EnumDecl, EnumeratorDecl, ExprStmt, FileJp, FloatLiteral, FunctionJp, GotoStmt, If, Include, IntLiteral, Literal, Loop, NamedDecl, Omp, Pragma, Program, RecordJp, ReturnStmt, Scope, Statement, Switch, Tag, Type, TypedefDecl, Vardecl, Varref, WrapperStmt } from "../Joinpoints.js";
+import Clava from "../clava/Clava.js";
 export default class ClavaAstConverter {
+    updateAst() {
+        Clava.rebuild();
+    }
     getJoinPointInfo(jp) {
         const info = {
             'AST ID': jp.astId,

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -230,7 +230,7 @@ export default class ClavaAstConverter {
         code = code.replaceAll(/(?<!>)(\/\*.*?\*\/)/g, `${openingTag}$1${closingTag}`);
         if (node.jp instanceof Declarator || node.jp instanceof EnumeratorDecl) {
             const [openingTag, closingTag] = this.getSpanTags('class="type"');
-            const regex = new RegExp(`\\s*[&*]*${node.jp.name}\\b`);
+            const regex = new RegExp(`\\s*[&*]*\\b${node.jp.name}\\b`);
             const namePos = code.search(regex);
             return namePos <= 0 ? code : openingTag + code.slice(0, namePos) + closingTag + code.slice(namePos);
         }

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -1,15 +1,109 @@
 import ToolJoinPoint from "lara-js/api/visualization/public/js/ToolJoinPoint.js";
-import { IntLiteral, TypedefDecl } from "../Joinpoints.js";
+import { AdjustedType, BoolLiteral, Call, Class, FileJp, FloatLiteral, Include, IntLiteral, Loop, Marker, NamedDecl, Omp, Pragma, Program, Tag, Type, TypedefDecl, Varref, WrapperStmt } from "../Joinpoints.js";
 import Clava from "../clava/Clava.js";
 export default class ClavaAstConverter {
     getJoinPointInfo(jp) {
         const info = {
             'AST ID': jp.astId,
-            'AST Name': jp.astName,
+            'AST name': jp.astName,
         };
+        if (jp instanceof FileJp) {
+            Object.assign(info, {
+                'File name': jp.name,
+                'Source folder': jp.sourceFoldername,
+                'Relative path': jp.relativeFilepath,
+                'Is C++': jp.isCxx,
+                'Is header file': jp.isHeader,
+                'Has main': jp.hasMain
+            });
+        }
+        if (jp instanceof Include) {
+            Object.assign(info, {
+                'Include name': jp.name,
+            });
+        }
+        if (jp instanceof NamedDecl) {
+            Object.assign(info, {
+                'Name': jp.name,
+            });
+        }
+        if (jp instanceof Pragma) {
+            Object.assign(info, {
+                'Pragma name': jp.name,
+            });
+        }
+        if (jp instanceof Program) {
+            Object.assign(info, {
+                'Program name': jp.name,
+                'Standard': jp.standard,
+            });
+        }
+        if (jp instanceof Tag) {
+            Object.assign(info, {
+                'Pragma ID': jp.id,
+            });
+        }
+        if (jp instanceof Type) {
+            Object.assign(info, {
+                'Constant?': jp.constant,
+                'Is builtin': jp.isBuiltin,
+                'Has sugar': jp.hasSugar,
+            });
+        }
+        if (jp instanceof Varref) {
+            Object.assign(info, {
+                'Name': jp.name,
+            });
+        }
+        if (jp instanceof WrapperStmt) {
+            Object.assign(info, {
+                'Wrapper type': jp.kind,
+            });
+        }
+        if (jp instanceof AdjustedType) {
+            Object.assign(info, {
+                'Original type': jp.originalType,
+            });
+        }
+        if (jp instanceof BoolLiteral) {
+            Object.assign(info, {
+                'Value': jp.value.toString(),
+            });
+        }
+        if (jp instanceof Call) {
+            Object.assign(info, {
+                'Function name': jp.name,
+            });
+        }
+        if (jp instanceof Class) {
+            Object.assign(info, {
+                'Is interface': jp.isInterface,
+            });
+        }
+        if (jp instanceof FloatLiteral) {
+            Object.assign(info, {
+                'Value': jp.value.toString(),
+            });
+        }
         if (jp instanceof IntLiteral) {
             Object.assign(info, {
                 'Value': jp.value.toString(),
+            });
+        }
+        if (jp instanceof Loop) {
+            Object.assign(info, {
+                'Loop ID': jp.id,
+                'Loop kind': jp.kind,
+            });
+        }
+        if (jp instanceof Marker) {
+            Object.assign(info, {
+                'Marker ID': jp.id,
+            });
+        }
+        if (jp instanceof Omp) {
+            Object.assign(info, {
+                'Omp kind': jp.kind,
             });
         }
         return info;

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -240,11 +240,12 @@ export default class ClavaAstConverter {
                 || node.jp instanceof Continue || node.jp instanceof GotoStmt || node.jp instanceof ReturnStmt
                 || node.jp instanceof EnumDecl || node.jp instanceof AccessSpecifier
                 || node.jp.astName == "FunctionTemplateDecl" || node.jp.astName == "TemplateTypeParmDecl") {
-                return code.replace(/^(\w+)(?=\W)/s, `${openingTag}$1${closingTag}`); // Highlight first word
+                return code.replace(/^(\w+)\b/s, `${openingTag}$1${closingTag}`); // Highlight first word
             }
             if (node.jp instanceof If) {
-                const elsePos = code.search(/(?<!>)\belse\b/);
-                if (elsePos !== -1) {
+                const elseMatch = code.match(/^(([^/]|\/[^/*]|\/\/.*|\/\*([^*]|\*[^/])*\*\/)*?)(?<!>)\belse\b/);
+                if (elseMatch) {
+                    const elsePos = elseMatch[1].length;
                     return openingTag + 'if' + closingTag + code.slice(2, elsePos) + openingTag + 'else' + closingTag + code.slice(elsePos + 4);
                 }
                 else {
@@ -253,7 +254,7 @@ export default class ClavaAstConverter {
             }
             if (node.jp instanceof Loop) {
                 if (node.jp.kind == "dowhile") {
-                    const whilePos = code.search(/(?<!>)\while\b/);
+                    const whilePos = code.match(/^(([^/]|\/[^/*]|\/\/.*|\/\*([^*]|\*[^/])*\*\/)*?)(?<!>)\bwhile\b/)[1].length;
                     return openingTag + 'do' + closingTag + code.slice(2, whilePos) + openingTag + 'while' + closingTag + code.slice(whilePos + 5);
                 }
                 else {
@@ -264,10 +265,10 @@ export default class ClavaAstConverter {
                 return openingTag + 'typedef' + closingTag + code.slice(7);
             }
             if (node.jp instanceof RecordJp) {
-                return code.replace(/^(.*?)(class(?!=)|struct)(.*)$/s, `$1${openingTag}$2${closingTag}$3`); // Highlight 'class' or 'struct' in declaration
+                return code.replace(/(class(?!=)|struct)/s, `$1${openingTag}$2${closingTag}$3`); // Highlight 'class' or 'struct' in declaration
             }
             if (node.jp instanceof Include || node.jp instanceof Pragma) {
-                return code.replace(/^(#\w+)(?=\W)/s, `${openingTag}$1${closingTag}`);
+                return code.replace(/^(#\w+)\b/s, `${openingTag}$1${closingTag}`);
             }
         }
         return code;

--- a/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/ClavaAstConverter.js
@@ -37,6 +37,13 @@ export default class ClavaAstConverter {
             const newIndentation = ['body', 'class'].includes(node.jp.joinPointType) ? indentation + 1 : indentation;
             this.refineCode(child, newIndentation);
         }
+        if (node.jp.joinPointType == 'body' && node.jp.naked) {
+            const match = node.code.match(/^([^\/]*\S)\s*(\/\/.*)$/);
+            if (match) {
+                const [, statement, comment] = match;
+                node.code = statement + '  ' + comment;
+            }
+        } // Fix space between statement and inline comment in naked body
         if (node.children.length >= 1 && node.children[0].jp.astName === 'TagDeclVars') {
             const tagDeclVars = node.children[0];
             const typedef = tagDeclVars.children[0];

--- a/ClavaLaraApi/src-lara/clava/visualization/VisualizationTool.js
+++ b/ClavaLaraApi/src-lara/clava/visualization/VisualizationTool.js
@@ -1,0 +1,14 @@
+import GenericVisualizationTool from 'lara-js/api/visualization/GenericVisualizationTool.js';
+import ClavaAstConverter from './ClavaAstConverter.js';
+export class VisualizationTool extends GenericVisualizationTool {
+    joinPointConverter = new ClavaAstConverter();
+    static instance = new VisualizationTool();
+    static getInstance() {
+        return this.instance;
+    }
+    getAstConverter() {
+        return this.joinPointConverter;
+    }
+}
+export default VisualizationTool.getInstance();
+//# sourceMappingURL=VisualizationTool.js.map


### PR DESCRIPTION
# Description

This PR adds a visualization tool that allows the visual mapping of the source code to the AST. This tool was develop on the context of the summer internship with topic "[CSE01] Visual Mapping of Source Code to Abstract Syntax Tree (AST)", from the INESC TEC Summer Internship 2024 programme.

To be precise, this PR creates the specialization of the tool for Clava. So, this  [PR](https://github.com/specs-feup/lara-framework/pull/71) must be merged *before* merging this one.

# Changes Made

- Added specializations of `GenericVisualizationTool` and `GenericAstConverter`, defined in the LARA API, that implements the needed operations for the Clava compiler.

# How Has This Been Tested

This was mainly tested manually. As the time of writing, I am still doing some final stress testing for possible bugs, so you may see some minor fixes in the future.