### PR TITLE
Adds Clava.clearAstHistory()

### DIFF
--- a/Clava-JS/src-api/clava/Clava.ts
+++ b/Clava-JS/src-api/clava/Clava.ts
@@ -153,6 +153,13 @@ extern "C" {
   }
 
   /**
+   * Clears all ASTs except for the one at the top of the stack. If there is one of none AST on the stack does nothing.
+   */
+  static clearAstHistory() {
+    Weaver.getWeaverEngine().clearAppHistory();
+  }
+
+  /**
    * The current number of elements in the AST stack.
    */
   static getStackSize() {

--- a/ClavaAst/src/pt/up/fe/specs/clava/context/ClavaContext.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/context/ClavaContext.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2018 SPeCS.
- * 
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * <p>
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License. under the License.
@@ -13,22 +13,17 @@
 
 package pt.up.fe.specs.clava.context;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 import org.suikasoft.jOptions.DataStore.ADataClass;
 import org.suikasoft.jOptions.Datakey.DataKey;
 import org.suikasoft.jOptions.Datakey.KeyFactory;
-
 import pt.up.fe.specs.clava.ast.extra.App;
 import pt.up.fe.specs.util.SpecsCheck;
 import pt.up.fe.specs.util.SpecsCollections;
 import pt.up.fe.specs.util.utilities.CachedItems;
 import pt.up.fe.specs.util.utilities.IdGenerator;
+
+import java.io.File;
+import java.util.*;
 
 public class ClavaContext extends ADataClass<ClavaContext> {
 
@@ -128,6 +123,19 @@ public class ClavaContext extends ADataClass<ClavaContext> {
         return previousApp;
     }
 
+    /**
+     * Only last element of the app list remains.
+     */
+    public void clearAppHistory() {
+        if (appStack.size() < 2) {
+            return;
+        }
+
+        var lastApp = SpecsCollections.last(appStack);
+        appStack.clear();
+        appStack.add(lastApp);
+    }
+
     public App popApp() {
         App app = appStack.remove(appStack.size() - 1);
 
@@ -156,15 +164,16 @@ public class ClavaContext extends ADataClass<ClavaContext> {
      * Returns the nth app from the top of the stack.<br>
      * <br>
      * E.g., if index is 1, returns the App immediately under the top of the stack.
+     *
      * @param index
      * @return the nth app from the top of the stack, or empty if none exists
      */
     public Optional<App> getApp(int index) {
-        if(index >= appStack.size()) {
+        if (index >= appStack.size()) {
             return Optional.empty();
         }
 
-        return Optional.of(appStack.get(appStack.size()-index-1));
+        return Optional.of(appStack.get(appStack.size() - index - 1));
     }
 
     // public <T> T get(DataKey<T> key) {

--- a/ClavaLaraApi/src-lara/clava/clava/Clava.js
+++ b/ClavaLaraApi/src-lara/clava/clava/Clava.js
@@ -114,6 +114,12 @@ extern "C" {
         Clava.getProgram().pop();
     }
     /**
+     * Clears all ASTs except for the one at the top of the stack. If there is one of none AST on the stack does nothing.
+     */
+    static clearAstHistory() {
+        Weaver.getWeaverEngine().clearAppHistory();
+    }
+    /**
      * The current number of elements in the AST stack.
      */
     static getStackSize() {

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/ClavaWeaverData.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/ClavaWeaverData.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2017 SPeCS.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License. under the License.
@@ -13,20 +13,7 @@
 
 package pt.up.fe.specs.clava.weaver;
 
-import java.io.File;
-import java.util.ArrayDeque;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
-
 import org.suikasoft.jOptions.Interfaces.DataStore;
-
 import pt.up.fe.specs.clava.ClavaLog;
 import pt.up.fe.specs.clava.ClavaNode;
 import pt.up.fe.specs.clava.ast.extra.App;
@@ -35,6 +22,10 @@ import pt.up.fe.specs.clava.weaver.pragmas.ClavaPragmas;
 import pt.up.fe.specs.util.SpecsCheck;
 import pt.up.fe.specs.util.SpecsLogs;
 import pt.up.fe.specs.util.SpecsStrings;
+
+import java.io.File;
+import java.util.*;
+import java.util.Map.Entry;
 
 public class ClavaWeaverData {
 
@@ -132,7 +123,7 @@ public class ClavaWeaverData {
     }
 
     private Map<ClavaNode, Map<String, Object>> getUserValuesCopy(App app, App previousApp,
-            Map<ClavaNode, Map<String, Object>> userValues) {
+                                                                  Map<ClavaNode, Map<String, Object>> userValues) {
 
         // When there are no user values
         if (userValues == null || userValues.isEmpty()) {
@@ -196,6 +187,20 @@ public class ClavaWeaverData {
 
         return topApp;
     }
+
+    private void clearAppHistory() {
+        // Clear ASTs
+        context.clearAppHistory();
+
+        // Clear user values
+        if (userValuesStack.size() >= 2) {
+            var top = userValuesStack.pop();
+            userValuesStack.clear();
+            userValuesStack.push(top);
+        }
+
+    }
+
 
     public void setGeneratedFiles(Collection<File> generatedFiles) {
         this.generatedFiles = new HashSet<>(generatedFiles);

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxWeaver.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxWeaver.java
@@ -1,21 +1,5 @@
 package pt.up.fe.specs.clava.weaver;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.logging.Level;
-import java.util.stream.Collectors;
-
 import org.lara.interpreter.joptions.config.interpreter.LaraiKeys;
 import org.lara.interpreter.profile.WeavingReport;
 import org.lara.interpreter.weaver.ast.AstMethods;
@@ -29,7 +13,6 @@ import org.lara.language.specification.dsl.LanguageSpecificationV2;
 import org.suikasoft.jOptions.Interfaces.DataStore;
 import org.suikasoft.jOptions.storedefinition.StoreDefinition;
 import org.suikasoft.jOptions.storedefinition.StoreDefinitionBuilder;
-
 import pt.up.fe.specs.antarex.clava.AntarexClavaLaraApis;
 import pt.up.fe.specs.antarex.clava.JsAntarexApiResource;
 import pt.up.fe.specs.clang.ClangAstKeys;
@@ -60,17 +43,19 @@ import pt.up.fe.specs.clava.weaver.utils.ClavaAstMethods;
 import pt.up.fe.specs.lara.langspec.LangSpecsXmlParser;
 import pt.up.fe.specs.lara.lcl.LaraCommonLanguageApis;
 import pt.up.fe.specs.lara.unit.LaraUnitLauncher;
-import pt.up.fe.specs.util.SpecsCheck;
-import pt.up.fe.specs.util.SpecsCollections;
-import pt.up.fe.specs.util.SpecsIo;
-import pt.up.fe.specs.util.SpecsLogs;
-import pt.up.fe.specs.util.SpecsSystem;
+import pt.up.fe.specs.util.*;
 import pt.up.fe.specs.util.collections.AccumulatorMap;
 import pt.up.fe.specs.util.lazy.Lazy;
 import pt.up.fe.specs.util.providers.ResourceProvider;
 import pt.up.fe.specs.util.utilities.Buffer;
 import pt.up.fe.specs.util.utilities.LineStream;
 import pt.up.fe.specs.util.utilities.StringLines;
+
+import java.io.File;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 /**
  * Weaver Implementation for CxxWeaver<br>
@@ -120,8 +105,8 @@ public class CxxWeaver extends ACxxWeaver {
             "https://github.com/specs-feup/clava-benchmarks.git?folder=Rosetta");
 
     /**
-     * @deprecated
      * @return
+     * @deprecated
      */
     @Deprecated
     public static LanguageSpecification buildLanguageSpecificationOld() {
@@ -174,6 +159,7 @@ public class CxxWeaver extends ACxxWeaver {
     private static final String CLAVA_API_NAME = "@specs-feup/clava";
 
     private static final List<ResourceProvider> CLAVA_LARA_API = new ArrayList<>();
+
     static {
         CLAVA_LARA_API.addAll(LaraCommonLanguageApis.getApis());
         CLAVA_LARA_API.addAll(ClavaLaraApis.getApis());
@@ -371,12 +357,9 @@ public class CxxWeaver extends ACxxWeaver {
     /**
      * Set a file/folder in the weaver if it is valid file/folder type for the weaver.
      *
-     * @param source
-     *            the file with the source code
-     * @param outputDir
-     *            output directory for the generated file(s)
-     * @param args
-     *            arguments to start the weaver
+     * @param source    the file with the source code
+     * @param outputDir output directory for the generated file(s)
+     * @param args      arguments to start the weaver
      * @return true if the file type is valid
      */
     @Override
@@ -547,13 +530,12 @@ public class CxxWeaver extends ACxxWeaver {
 
     /**
      * Updates the information relative to the current sources.
-     * 
+     *
      * <p>
      * Creation of sources follow this rules:<br>
      * 1) Single files listed in 'sources' are considered to not have a base folder (relative path is null) <br>
      * 2) Source folders listed in 'sources' will have the parent folder as its base folder <br>
      * 3) Source files or folders listed in 'map' will have the base folder indicated in the map
-     * 
      */
     private void updateSources(Map<File, File> map) {
         // TODO: Convert all folders to files, folders become bases when in sources
@@ -755,7 +737,7 @@ public class CxxWeaver extends ACxxWeaver {
 
     /**
      * Builds the -I argument
-     * 
+     *
      * @param include
      * @return
      */
@@ -769,13 +751,11 @@ public class CxxWeaver extends ACxxWeaver {
     }
 
     /**
-     *
      * @param sources
      * @param parserOptions
-     * @param extraOptions
-     *            options that should not be processed (e.g., header files found in folders specified by -I flags are
-     *            automatically added to the compilation, if we want to add header folders whose header files should not
-     *            be parsed, they can be specified here)
+     * @param extraOptions  options that should not be processed (e.g., header files found in folders specified by -I flags are
+     *                      automatically added to the compilation, if we want to add header folders whose header files should not
+     *                      be parsed, they can be specified here)
      * @return
      */
     public App createApp(List<File> sources, List<String> parserOptions, List<String> extraOptions) {
@@ -1568,9 +1548,7 @@ public class CxxWeaver extends ACxxWeaver {
     }
 
     /**
-     *
-     * @param update
-     *            if true, the weaver will update its state to use the rebuilt tree instead of the original tree
+     * @param update if true, the weaver will update its state to use the rebuilt tree instead of the original tree
      */
     public boolean rebuildAst(boolean update) {
         // Check if inside apply
@@ -1726,10 +1704,10 @@ public class CxxWeaver extends ACxxWeaver {
 
     /**
      * Creates a new temporary folder for weaving.
-     * 
+     *
      * <p>
      * The folder will be deleted when the JVM exits.
-     * 
+     *
      * @return
      */
     private static File newTemporaryWeavingFolder() {
@@ -1897,11 +1875,11 @@ public class CxxWeaver extends ACxxWeaver {
 
     /**
      * Helper method which returns include folders of the source files.
-     * 
+     *
      * <p>
      * For the temporary folder, the source folders are the children folders of the temporary folder, and the temporary
      * folder itself.
-     * 
+     *
      * @param weavingFolder
      * @return
      */
@@ -1911,7 +1889,7 @@ public class CxxWeaver extends ACxxWeaver {
 
     /**
      *
-    */
+     */
     private Set<File> getSourceIncludeFolders(File weavingFolder, boolean onlyHeaders) {
         Set<File> includeFolders = new LinkedHashSet<>();
         includeFolders.addAll(SpecsIo.getFolders(weavingFolder));
@@ -2077,4 +2055,7 @@ public class CxxWeaver extends ACxxWeaver {
         return Arrays.asList(ClavaApiJsResource.values());
     }
 
+    public void clearAppHistory() {
+        context.clearAppHistory();
+    }
 }


### PR DESCRIPTION
Clava supports storing ASTs to a stack structure, where the currently active one is always the one on top of the stack.

This PR adds the method `Clava.clearAstHistory()` which clears any ASTs in the stack besides the one on top, that is currently active.