### PR TITLE
Potential fix for code scanning alert no. 4: Inefficient regular expression

### DIFF
--- a/ClavaLaraApi/src-lara/clava/clava/vitishls/VitisHlsReportParser.js
+++ b/ClavaLaraApi/src-lara/clava/clava/vitishls/VitisHlsReportParser.js
@@ -6,7 +6,7 @@ export default class VitisHlsReportParser {
     }
     xmlToJson(xml) {
         //parses only the "leaves" of the XML string, which is enough for us. For now.
-        const regex = /(?:<([a-zA-Z'-\d_]*)(?:\s[^>]*)*>)((?:(?!<\1).)*)(?:<\/\1>)|<([a-zA-Z'-]*)(?:\s*)*\/>/gm;
+        const regex = /(?:<([a-zA-Z'-\d_]*)(?:\s[^>]*)*>)((?:(?!<\1).)*)(?:<\/\1>)|<([a-zA-Z'-]*)(?:\s*)\/>/gm;
         const json = {};
         for (const match of xml.matchAll(regex)) {
             const key = match[1] || match[3];


### PR DESCRIPTION
Potential fix for [https://github.com/specs-feup/clava/security/code-scanning/4](https://github.com/specs-feup/clava/security/code-scanning/4)

To fix the problem, we need to remove the ambiguous repetition in the regular expression, specifically the use of `(?:\s*)*` (or similar) which can cause exponential backtracking. In the self-closing tag part of the regex (`<([a-zA-Z'-]*)(?:\s*)*\/>`), the repetition of `\s*` is unnecessary and can be replaced with a single `\s*` to match any amount of whitespace. The corrected pattern should be `<([a-zA-Z'-]*)(?:\s*)\/>`, which matches a tag name followed by optional whitespace and then a self-closing slash. Only line 9 needs to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
