### PR TITLE
Potential fix for code scanning alert no. 3: Inefficient regular expression

### DIFF
--- a/ClavaLaraApi/src-lara/clava/clava/vitishls/VitisHlsReportParser.js
+++ b/ClavaLaraApi/src-lara/clava/clava/vitishls/VitisHlsReportParser.js
@@ -6,7 +6,7 @@ export default class VitisHlsReportParser {
     }
     xmlToJson(xml) {
         //parses only the "leaves" of the XML string, which is enough for us. For now.
-        const regex = /(?:<([a-zA-Z'-\d_]*)(?:\s[^>]*)*>)((?:(?!<\1).)*)(?:<\/\1>)|<([a-zA-Z'-]*)(?:\s*)*\/>/gm;
+        const regex = /(?:<([a-zA-Z'-\d_]*)(?:\s[^<>]*)*>)((?:(?!<\/\1>).)*)(?:<\/\1>)|<([a-zA-Z'-]*)(?:\s*)*\/>/gm;
         const json = {};
         for (const match of xml.matchAll(regex)) {
             const key = match[1] || match[3];


### PR DESCRIPTION
Potential fix for [https://github.com/specs-feup/clava/security/code-scanning/3](https://github.com/specs-feup/clava/security/code-scanning/3)

To fix the issue, we will rewrite the regular expression to eliminate the ambiguity caused by `[^>]*`. Specifically, we will replace it with a more precise pattern that avoids backtracking. The sub-expression `[^>]*` will be replaced with a non-greedy match for any sequence of characters that does not include the closing tag. This can be achieved by using a negated character class or by restructuring the regex to avoid ambiguity.

The updated regex will ensure that it matches the intended XML patterns without introducing inefficiencies. The changes will be made directly in the `regex` variable on line 9.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
