### PR TITLE
Potential fix for code scanning alert no. 2: Inefficient regular expression

### DIFF
--- a/Clava-JS/src-api/clava/vitishls/VitisHlsReportParser.ts
+++ b/Clava-JS/src-api/clava/vitishls/VitisHlsReportParser.ts
@@ -10,7 +10,7 @@ export default class VitisHlsReportParser {
   private xmlToJson(xml: string) {
     //parses only the "leaves" of the XML string, which is enough for us. For now.
     const regex =
-      /(?:<([a-zA-Z'-\d_]*)(?:\s[^>]*)*>)((?:(?!<\1).)*)(?:<\/\1>)|<([a-zA-Z'-]*)(?:\s*)*\/>/gm;
+      /(?:<([a-zA-Z'-\d_]*)(?:\s[^>]*)*>)((?:(?!<\1).)*)(?:<\/\1>)|<([a-zA-Z'-]*)\s*\/>/gm;
 
     const json: Record<string, any> = {};
     for (const match of xml.matchAll(regex)) {


### PR DESCRIPTION
Potential fix for [https://github.com/specs-feup/clava/security/code-scanning/2](https://github.com/specs-feup/clava/security/code-scanning/2)

To fix the inefficient regular expression, we should remove the ambiguity caused by the use of `\s*` inside a repeated or alternated context. Specifically, we can replace `\s*` with a more precise pattern that matches only the whitespace between tag name and `/`, and avoid unnecessary repetition. For the self-closing tag pattern `<([a-zA-Z'-]*)(?:\s*)*\/>`, we can replace `(?:\s*)*` with simply `\s*`, as multiple repetitions of `\s*` are equivalent to a single `\s*` and do not add value but do add ambiguity. This change will not affect the functionality but will improve performance and avoid catastrophic backtracking.

Edit only line 13 in Clava-JS/src-api/clava/vitishls/VitisHlsReportParser.ts, replacing `(?:\s*)*` with `\s*` in the self-closing tag pattern.

No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
