### PR TITLE
Potential fix for code scanning alert no. 1: Inefficient regular expression

### DIFF
--- a/Clava-JS/src-api/clava/vitishls/VitisHlsReportParser.ts
+++ b/Clava-JS/src-api/clava/vitishls/VitisHlsReportParser.ts
@@ -10,7 +10,7 @@ export default class VitisHlsReportParser {
   private xmlToJson(xml: string) {
     //parses only the "leaves" of the XML string, which is enough for us. For now.
     const regex =
-      /(?:<([a-zA-Z'-\d_]*)(?:\s[^>]*)*>)((?:(?!<\1).)*)(?:<\/\1>)|<([a-zA-Z'-]*)(?:\s*)*\/>/gm;
+      /(?:<([a-zA-Z'-\d_]+)(?:\s[^>]*)?>)([\s\S]*?)<\/\1>|<([a-zA-Z'-]+)(?:\s*)?\/>/gm;
 
     const json: Record<string, any> = {};
     for (const match of xml.matchAll(regex)) {


### PR DESCRIPTION
Potential fix for [https://github.com/specs-feup/clava/security/code-scanning/1](https://github.com/specs-feup/clava/security/code-scanning/1)

To fix the inefficient regular expression, we need to remove ambiguity and nested quantifiers that can cause exponential backtracking. The problematic part is `[^>]*`, which matches any sequence of characters except `>`, but when combined with other quantifiers and alternations, can lead to performance issues. The best way to fix this is to make the pattern more specific and less ambiguous, especially inside repeated groups. For XML tag parsing, we should avoid ambiguous alternations and greedy quantifiers. One approach is to replace `[^>]*` with a non-greedy match for anything except `>`, or to use a more precise pattern that matches tag contents without ambiguity. We should also ensure that the pattern does not allow for multiple ways to match the same substring.

Specifically, in the regex:
```ts
/(?:<([a-zA-Z'-\d_]*)(?:\s[^>]*)*>)((?:(?!<\1).)*)(?:<\/\1>)|<([a-zA-Z'-]*)(?:\s*)*\/>/gm
```
We can replace `[^>]*` with a more precise pattern, such as `[^>]*?` (non-greedy), or better, restrict the whitespace matching to avoid ambiguity. Additionally, we can replace `((?:(?!<\1).)*)` with a more efficient pattern, such as `([\s\S]*?)`, which matches any character non-greedily. The alternation for self-closing tags can also be made more precise.

**Required changes:**  
- Update the regex on line 13 to remove ambiguous quantifiers and alternations.
- No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
