### PR TITLE
refactor: remove intermediate-file cleanup option

### DIFF
--- a/ClangAstParser/src/pt/up/fe/specs/clang/dumper/ClangAstDumper.java
+++ b/ClangAstParser/src/pt/up/fe/specs/clang/dumper/ClangAstDumper.java
@@ -62,16 +62,6 @@ public class ClangAstDumper {
     private final static String CLANG_DUMP_FILENAME = "clangDump.txt";
     private final static String STDERR_DUMP_FILENAME = "stderr.txt";
 
-    private static final List<String> CLANG_AST_DUMPER_TEMP_FILES = List.of("includes.txt", CLANG_DUMP_FILENAME,
-            // "clavaDump.txt", "nodetypes.txt", "types.txt", "is_temporary.txt", "template_args.txt",
-            "clavaDump.txt", "nodetypes.txt", "types.txt", "is_temporary.txt",
-            "omp.txt", "invalid_source.txt", "enum_integer_type.txt", "consumer_order.txt",
-            "types_with_templates.txt");
-
-    public static List<String> getTempFiles() {
-        return CLANG_AST_DUMPER_TEMP_FILES;
-    }
-
     /**
      * TODO: Not implemented yet
      * <p>

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxWeaver.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxWeaver.java
@@ -12,7 +12,6 @@ import pt.up.fe.specs.clang.ClangAstKeys;
 import pt.up.fe.specs.clang.SupportedPlatform;
 import pt.up.fe.specs.clang.codeparser.CodeParser;
 import pt.up.fe.specs.clang.codeparser.ParallelCodeParser;
-import pt.up.fe.specs.clang.dumper.ClangAstDumper;
 import pt.up.fe.specs.clava.ClavaLog;
 import pt.up.fe.specs.clava.ClavaNode;
 import pt.up.fe.specs.clava.ClavaOptions;
@@ -797,13 +796,6 @@ public class CxxWeaver extends ACxxWeaver {
         SpecsIo.deleteFolder(new File(TEMP_SRC_FOLDER));
 
         if (this.dataStore != null) {
-            // Delete intermediary files
-            if (this.dataStore.get(CxxWeaverOption.CLEAN_INTERMEDIATE_FILES)) {
-                for (String tempFile : ClangAstDumper.getTempFiles()) {
-                    new File(tempFile).delete();
-                }
-            }
-
             // Re-enable output
             if (this.dataStore.get(CxxWeaverOption.DISABLE_CLAVA_INFO)) {
                 SpecsLogs.getSpecsLogger().setLevelAll(null);

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/options/CxxWeaverOption.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/options/CxxWeaverOption.java
@@ -37,9 +37,6 @@ public interface CxxWeaverOption {
     DataKey<Boolean> CHECK_SYNTAX = KeyFactory.bool("Check C/CXX Syntax")
             .setLabel("Check C/C++ syntax (performs additional parsing step)");
 
-    DataKey<Boolean> CLEAN_INTERMEDIATE_FILES = KeyFactory.bool("Clean intermediate files")
-            .setDefault(() -> true);
-
     DataKey<FileList> HEADER_INCLUDES = LaraIKeyFactory.folderList("header includes")
             .setLabel("Normal Includes")
             .setDefault(FileList::newInstance);
@@ -85,7 +82,7 @@ public interface CxxWeaverOption {
 
     StoreDefinition STORE_DEFINITION = new StoreDefinitionBuilder("C/C++ Weaver")
             .addKeys(ClavaOptions.STORE_DEFINITION.getKeys())
-            .addKeys(WOVEN_CODE_FOLDERNAME, DISABLE_CLAVA_INFO, CHECK_SYNTAX, CLEAN_INTERMEDIATE_FILES,
+            .addKeys(WOVEN_CODE_FOLDERNAME, DISABLE_CLAVA_INFO, CHECK_SYNTAX,
                     HEADER_INCLUDES,
                     // SKIP_HEADER_INCLUDES_PARSING,
                     PARSE_INCLUDES,

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/options/CxxWeaverOptions.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/options/CxxWeaverOptions.java
@@ -63,8 +63,6 @@ public class CxxWeaverOptions {
 
         addBooleanOption(CxxWeaverOption.CHECK_SYNTAX, "cs", "check-syntax", "Checks syntax of woven code");
 
-        addBooleanOption(CxxWeaverOption.CLEAN_INTERMEDIATE_FILES, "cl", "clean", "Clean intermediate files");
-
         addBooleanOption(CxxWeaverOption.DISABLE_CODE_GENERATION, "ncg", "no-code-gen",
                 "Disables automatic code generation");
 


### PR DESCRIPTION
Clava still exposed an option for deleting a list of intermediate files that the current dumper no longer owns. The list also contained stale file names and made debug artifacts disappear at the end of a run.

This removes the `CLEAN_INTERMEDIATE_FILES` option, its CLI registration, the end-of-run deletion loop, and the unused temporary-file list/accessor. The existing temporary parsing-folder cleanup is unchanged.

Verified with:

- `SPECS_JAVA_LIBS_HOME=... LARA_FRAMEWORK_HOME=... gradle -p ClavaWeaver compileJava`
- `git diff --check`

Model: GPT-5.6-Luna
