### PR TITLE
fix: support new clang-dumper template arguments

### DIFF
--- a/ClangAstParser/src/pt/up/fe/specs/clang/parsers/data/ClavaDataParsers.java
+++ b/ClangAstParser/src/pt/up/fe/specs/clang/parsers/data/ClavaDataParsers.java
@@ -38,11 +38,15 @@ import pt.up.fe.specs.clava.ast.decl.data.nestedname.SuperSpecifier;
 import pt.up.fe.specs.clava.ast.decl.data.nestedname.TypeSpecSpecifier;
 import pt.up.fe.specs.clava.ast.decl.data.nestedname.TypeSpecWithTemplateSpecifier;
 import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgument;
+import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentDeclaration;
 import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentExpr;
 import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentIntegral;
 import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentKind;
+import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentNullPtr;
 import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentPack;
+import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentStructuralValue;
 import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentTemplate;
+import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentTemplateExpansion;
 import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentType;
 import pt.up.fe.specs.clava.ast.decl.data.templates.template.QualifiedTemplate;
 import pt.up.fe.specs.clava.ast.decl.data.templates.template.SubstTemplateTemplateParm;
@@ -257,6 +261,14 @@ public class ClavaDataParsers {
         TemplateArgumentKind kind = LineStreamParsers.enumFromName(TemplateArgumentKind.class, lines);
 
         switch (kind) {
+        case Declaration:
+            TemplateArgumentDeclaration declaration = new TemplateArgumentDeclaration();
+            parserData.getClavaNodes().queueSetNode(declaration, TemplateArgumentDeclaration.DECL, lines.nextLine());
+            return declaration;
+        case NullPtr:
+            TemplateArgumentNullPtr nullPtr = new TemplateArgumentNullPtr();
+            parserData.getClavaNodes().queueSetNode(nullPtr, TemplateArgumentNullPtr.TYPE, lines.nextLine());
+            return nullPtr;
         case Type:
             TemplateArgumentType type = new TemplateArgumentType();
             parserData.getClavaNodes().queueSetNode(type, TemplateArgumentType.TYPE, lines.nextLine());
@@ -282,6 +294,19 @@ public class ClavaDataParsers {
             return integral;
         case Template:
             return templateArgumentTemplate(lines, parserData);
+        case TemplateExpansion:
+            TemplateArgumentTemplateExpansion expansion = new TemplateArgumentTemplateExpansion();
+            String numExpansions = lines.nextLine();
+            expansion.set(TemplateArgumentTemplateExpansion.NUM_EXPANSIONS,
+                    numExpansions.isEmpty() ? Optional.empty() : Optional.of(Integer.parseInt(numExpansions)));
+            expansion.set(TemplateArgumentTemplateExpansion.TEMPLATE,
+                    templateArgumentTemplate(lines, parserData));
+            return expansion;
+        case StructuralValue:
+            TemplateArgumentStructuralValue structuralValue = new TemplateArgumentStructuralValue();
+            parserData.getClavaNodes().queueSetNode(structuralValue, TemplateArgumentStructuralValue.TYPE,
+                    lines.nextLine());
+            return structuralValue;
         /*
         // TemplateArgumentTemplate template = new TemplateArgumentTemplate();
         TemplateNameKind nameKind = LineStreamParsers.enumFromName(TemplateNameKind.class, lines);

--- a/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/TemplateArgumentDeclaration.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/TemplateArgumentDeclaration.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2026 SPeCS.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package pt.up.fe.specs.clava.ast.decl.data.templates;
+
+import org.suikasoft.jOptions.Datakey.DataKey;
+import org.suikasoft.jOptions.Datakey.KeyFactory;
+
+import pt.up.fe.specs.clava.ast.decl.Decl;
+
+public class TemplateArgumentDeclaration extends TemplateArgument {
+
+    /// DATAKEYS BEGIN
+
+    public final static DataKey<Decl> DECL = KeyFactory.object("decl", Decl.class);
+
+    /// DATAKEYS END
+
+    public TemplateArgumentDeclaration() {
+        super(TemplateArgumentKind.Declaration);
+    }
+}

--- a/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/TemplateArgumentKind.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/TemplateArgumentKind.java
@@ -39,5 +39,9 @@ public enum TemplateArgumentKind {
     /**
      * A parameter pack.
      */
-    Pack
+    Pack,
+    /**
+     * A structural value for a non-type template parameter.
+     */
+    StructuralValue
 }

--- a/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/TemplateArgumentNullPtr.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/TemplateArgumentNullPtr.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2026 SPeCS.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package pt.up.fe.specs.clava.ast.decl.data.templates;
+
+import org.suikasoft.jOptions.Datakey.DataKey;
+import org.suikasoft.jOptions.Datakey.KeyFactory;
+
+import pt.up.fe.specs.clava.ClavaNode;
+import pt.up.fe.specs.clava.ast.type.Type;
+
+public class TemplateArgumentNullPtr extends TemplateArgument {
+
+    /// DATAKEYS BEGIN
+
+    public final static DataKey<Type> TYPE = KeyFactory.object("type", Type.class);
+
+    /// DATAKEYS END
+
+    public TemplateArgumentNullPtr() {
+        super(TemplateArgumentKind.NullPtr);
+    }
+
+    @Override
+    public String getCode(ClavaNode node) {
+        return "nullptr";
+    }
+}

--- a/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/TemplateArgumentStructuralValue.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/TemplateArgumentStructuralValue.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2026 SPeCS.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package pt.up.fe.specs.clava.ast.decl.data.templates;
+
+import org.suikasoft.jOptions.Datakey.DataKey;
+import org.suikasoft.jOptions.Datakey.KeyFactory;
+
+import pt.up.fe.specs.clava.ast.type.Type;
+
+public class TemplateArgumentStructuralValue extends TemplateArgument {
+
+    /// DATAKEYS BEGIN
+
+    public final static DataKey<Type> TYPE = KeyFactory.object("type", Type.class);
+
+    /// DATAKEYS END
+
+    public TemplateArgumentStructuralValue() {
+        super(TemplateArgumentKind.StructuralValue);
+    }
+}

--- a/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/TemplateArgumentTemplateExpansion.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/TemplateArgumentTemplateExpansion.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2026 SPeCS.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package pt.up.fe.specs.clava.ast.decl.data.templates;
+
+import java.util.Optional;
+
+import org.suikasoft.jOptions.Datakey.DataKey;
+import org.suikasoft.jOptions.Datakey.KeyFactory;
+
+import pt.up.fe.specs.clava.ClavaNode;
+
+public class TemplateArgumentTemplateExpansion extends TemplateArgument {
+
+    /// DATAKEYS BEGIN
+
+    public final static DataKey<Optional<Integer>> NUM_EXPANSIONS = KeyFactory.optional("numExpansions");
+
+    public final static DataKey<TemplateArgumentTemplate> TEMPLATE = KeyFactory.object("template",
+            TemplateArgumentTemplate.class);
+
+    /// DATAKEYS END
+
+    public TemplateArgumentTemplateExpansion() {
+        super(TemplateArgumentKind.TemplateExpansion);
+    }
+
+    @Override
+    public String getCode(ClavaNode node) {
+        return get(TEMPLATE).getCode(node) + "...";
+    }
+}


### PR DESCRIPTION
The future clang-dumper emits four template-argument kinds that Clava currently rejects.

This adds parser and AST support for `Declaration`, `NullPtr`, `TemplateExpansion`, and `StructuralValue`. The structural-value model keeps the serialized type; the current dumper does not serialize the value payload.

Verification:

- `gradle -p ClangAstParser compileJava`
- parsed the post-release `template_expansion_pack.cpp` corpus with a local build of clang-dumper and reparsed Clava's generated output

Model: GPT-5.6-Luna
