### PR TITLE
fix: support new clang-dumper template names

### DIFF
--- a/ClangAstParser/src/pt/up/fe/specs/clang/parsers/data/ClavaDataParsers.java
+++ b/ClangAstParser/src/pt/up/fe/specs/clang/parsers/data/ClavaDataParsers.java
@@ -362,7 +362,7 @@ public class ClavaDataParsers {
             parserData.getClavaNodes().queueSetNode(template, UsingTemplate.USING_SHADOW_DECL, lines.nextLine());
             break;
         case DependentTemplate:
-            template.set(DependentTemplate.QUALIFIER, nestedNameSpecifier(lines, parserData));
+            template.set(DependentTemplate.QUALIFIER, lines.nextLine());
             template.set(DependentTemplate.NAME, lines.nextLine());
             break;
         default:

--- a/ClangAstParser/src/pt/up/fe/specs/clang/parsers/data/ClavaDataParsers.java
+++ b/ClangAstParser/src/pt/up/fe/specs/clang/parsers/data/ClavaDataParsers.java
@@ -48,9 +48,11 @@ import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentStructuralVa
 import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentTemplate;
 import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentTemplateExpansion;
 import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentType;
+import pt.up.fe.specs.clava.ast.decl.data.templates.template.DependentTemplate;
 import pt.up.fe.specs.clava.ast.decl.data.templates.template.QualifiedTemplate;
 import pt.up.fe.specs.clava.ast.decl.data.templates.template.SubstTemplateTemplateParm;
 import pt.up.fe.specs.clava.ast.decl.data.templates.template.Template;
+import pt.up.fe.specs.clava.ast.decl.data.templates.template.UsingTemplate;
 import pt.up.fe.specs.clava.ast.decl.enums.ExplicitSpecKind;
 import pt.up.fe.specs.clava.ast.decl.enums.NestedNameSpecifierKind;
 import pt.up.fe.specs.clava.ast.expr.data.designator.ArrayDesignator;
@@ -355,6 +357,13 @@ public class ClavaDataParsers {
         case SubstTemplateTemplateParm:
             parserData.getClavaNodes().queueSetNode(template, SubstTemplateTemplateParm.PARAMETER, lines.nextLine());
             template.set(SubstTemplateTemplateParm.REPLACEMENT, templateArgumentTemplate(lines, parserData));
+            break;
+        case UsingTemplate:
+            parserData.getClavaNodes().queueSetNode(template, UsingTemplate.USING_SHADOW_DECL, lines.nextLine());
+            break;
+        case DependentTemplate:
+            template.set(DependentTemplate.QUALIFIER, nestedNameSpecifier(lines, parserData));
+            template.set(DependentTemplate.NAME, lines.nextLine());
             break;
         default:
             throw new RuntimeException("Case not implemented: " + nameKind);

--- a/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/TemplateArgumentTemplate.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/TemplateArgumentTemplate.java
@@ -16,9 +16,11 @@ package pt.up.fe.specs.clava.ast.decl.data.templates;
 import org.suikasoft.jOptions.Datakey.DataKey;
 import org.suikasoft.jOptions.Datakey.KeyFactory;
 
+import pt.up.fe.specs.clava.ast.decl.data.templates.template.DependentTemplate;
 import pt.up.fe.specs.clava.ast.decl.data.templates.template.QualifiedTemplate;
 import pt.up.fe.specs.clava.ast.decl.data.templates.template.SubstTemplateTemplateParm;
 import pt.up.fe.specs.clava.ast.decl.data.templates.template.Template;
+import pt.up.fe.specs.clava.ast.decl.data.templates.template.UsingTemplate;
 import pt.up.fe.specs.clava.ast.type.enums.TemplateNameKind;
 import pt.up.fe.specs.util.exceptions.NotImplementedException;
 
@@ -52,6 +54,10 @@ public abstract class TemplateArgumentTemplate extends TemplateArgument {
             return new QualifiedTemplate();
         case SubstTemplateTemplateParm:
             return new SubstTemplateTemplateParm();
+        case UsingTemplate:
+            return new UsingTemplate();
+        case DependentTemplate:
+            return new DependentTemplate();
         default:
             throw new NotImplementedException(nameKind);
         }

--- a/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/template/DependentTemplate.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/template/DependentTemplate.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2026 SPeCS.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package pt.up.fe.specs.clava.ast.decl.data.templates.template;
+
+import org.suikasoft.jOptions.Datakey.DataKey;
+import org.suikasoft.jOptions.Datakey.KeyFactory;
+
+import pt.up.fe.specs.clava.ClavaNode;
+import pt.up.fe.specs.clava.ast.decl.data.nestedname.NestedNameSpecifier;
+import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentTemplate;
+import pt.up.fe.specs.clava.ast.type.enums.TemplateNameKind;
+
+public class DependentTemplate extends TemplateArgumentTemplate {
+
+    /// DATAKEYS BEGIN
+
+    public final static DataKey<NestedNameSpecifier> QUALIFIER = KeyFactory.object("qualifier",
+            NestedNameSpecifier.class);
+
+    public final static DataKey<String> NAME = KeyFactory.string("name");
+
+    /// DATAKEYS END
+
+    public DependentTemplate() {
+        super(TemplateNameKind.DependentTemplate);
+    }
+
+    @Override
+    public String getCode(ClavaNode node) {
+        return get(QUALIFIER).getQualifier() + get(NAME);
+    }
+}

--- a/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/template/DependentTemplate.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/template/DependentTemplate.java
@@ -17,7 +17,6 @@ import org.suikasoft.jOptions.Datakey.DataKey;
 import org.suikasoft.jOptions.Datakey.KeyFactory;
 
 import pt.up.fe.specs.clava.ClavaNode;
-import pt.up.fe.specs.clava.ast.decl.data.nestedname.NestedNameSpecifier;
 import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentTemplate;
 import pt.up.fe.specs.clava.ast.type.enums.TemplateNameKind;
 
@@ -25,8 +24,7 @@ public class DependentTemplate extends TemplateArgumentTemplate {
 
     /// DATAKEYS BEGIN
 
-    public final static DataKey<NestedNameSpecifier> QUALIFIER = KeyFactory.object("qualifier",
-            NestedNameSpecifier.class);
+    public final static DataKey<String> QUALIFIER = KeyFactory.string("qualifier");
 
     public final static DataKey<String> NAME = KeyFactory.string("name");
 
@@ -38,6 +36,8 @@ public class DependentTemplate extends TemplateArgumentTemplate {
 
     @Override
     public String getCode(ClavaNode node) {
-        return get(QUALIFIER).getQualifier() + get(NAME);
+        String qualifier = get(QUALIFIER);
+        String templateKeyword = qualifier.isEmpty() ? "" : "template ";
+        return qualifier + templateKeyword + get(NAME);
     }
 }

--- a/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/template/UsingTemplate.java
+++ b/ClavaAst/src/pt/up/fe/specs/clava/ast/decl/data/templates/template/UsingTemplate.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2026 SPeCS.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package pt.up.fe.specs.clava.ast.decl.data.templates.template;
+
+import org.suikasoft.jOptions.Datakey.DataKey;
+import org.suikasoft.jOptions.Datakey.KeyFactory;
+
+import pt.up.fe.specs.clava.ClavaNode;
+import pt.up.fe.specs.clava.ast.decl.UsingShadowDecl;
+import pt.up.fe.specs.clava.ast.decl.data.templates.TemplateArgumentTemplate;
+import pt.up.fe.specs.clava.ast.type.enums.TemplateNameKind;
+
+public class UsingTemplate extends TemplateArgumentTemplate {
+
+    /// DATAKEYS BEGIN
+
+    public final static DataKey<UsingShadowDecl> USING_SHADOW_DECL = KeyFactory.object("usingShadowDecl",
+            UsingShadowDecl.class);
+
+    /// DATAKEYS END
+
+    public UsingTemplate() {
+        super(TemplateNameKind.UsingTemplate);
+    }
+
+    @Override
+    public String getCode(ClavaNode node) {
+        return get(USING_SHADOW_DECL).getDeclName();
+    }
+}


### PR DESCRIPTION
The future clang-dumper can serialize `UsingTemplate` and `DependentTemplate` names, but Clava currently rejects both kinds.

This adds AST models and parser support for the using-shadow declaration, dependent qualifier, and dependent name spelling emitted by clang-dumper.

Verification:

- `gradle -p ClangAstParser compileJava`
- `git diff --check`

Model: GPT-5.6-Luna
