### PR TITLE
perf: skip discarded syntax AST rebuild

### DIFF
--- a/ClangAstParser/src/pt/up/fe/specs/clang/codeparser/CodeParser.java
+++ b/ClangAstParser/src/pt/up/fe/specs/clang/codeparser/CodeParser.java
@@ -64,11 +64,6 @@ public abstract class CodeParser extends ADataClass<CodeParser> {
     public abstract App parse(List<File> sources, List<String> compilerOptions, ClavaContext context);
 
     /**
-     * Runs the configured compiler/dumper pipeline without decoding its AST output.
-     */
-    public abstract void validateSyntax(List<File> sources, List<String> compilerOptions, ClavaContext context);
-
-    /**
      *
      * @param sources
      * @param compilerOptions flags compatible with C/C++ compilers such as Clang or GCC

--- a/ClangAstParser/src/pt/up/fe/specs/clang/codeparser/CodeParser.java
+++ b/ClangAstParser/src/pt/up/fe/specs/clang/codeparser/CodeParser.java
@@ -64,6 +64,11 @@ public abstract class CodeParser extends ADataClass<CodeParser> {
     public abstract App parse(List<File> sources, List<String> compilerOptions, ClavaContext context);
 
     /**
+     * Runs the configured compiler/dumper pipeline without decoding its AST output.
+     */
+    public abstract void validateSyntax(List<File> sources, List<String> compilerOptions, ClavaContext context);
+
+    /**
      *
      * @param sources
      * @param compilerOptions flags compatible with C/C++ compilers such as Clang or GCC

--- a/ClangAstParser/src/pt/up/fe/specs/clang/codeparser/ParallelCodeParser.java
+++ b/ClangAstParser/src/pt/up/fe/specs/clang/codeparser/ParallelCodeParser.java
@@ -17,6 +17,7 @@ import org.suikasoft.jOptions.Datakey.DataKey;
 import org.suikasoft.jOptions.Datakey.KeyFactory;
 import org.suikasoft.jOptions.Interfaces.DataStore;
 import pt.up.fe.specs.clang.ClangAstKeys;
+import pt.up.fe.specs.clang.ClangFiles;
 import pt.up.fe.specs.clang.ClangResources;
 import pt.up.fe.specs.clang.dumper.ClangAstData;
 import pt.up.fe.specs.clang.dumper.ClangAstDumper;
@@ -70,6 +71,9 @@ public class ParallelCodeParser extends CodeParser {
     public static final DataKey<Boolean> CONTINUE_ON_PARSING_ERRORS = KeyFactory.bool("continueOnParsingErrors")
             .setLabel("Ignores parsing errors in C/C++ source code");
 
+    public static final DataKey<Boolean> SYNTAX_ONLY = KeyFactory.bool("syntaxOnly")
+            .setLabel("Runs the compiler/dumper pipeline only to validate syntax, without decoding the AST");
+
     // public static final DataKey<Integer> SYSTEM_INCLUDES_THRESHOLD = KeyFactory.integer("systemIncludesThreshold", 1)
     // .setLabel("Number of threads to use for parallel parsing");
 
@@ -86,6 +90,9 @@ public class ParallelCodeParser extends CodeParser {
         Map<String, File> allSources = SpecsIo.getFileMap(allSourceFolders, SourceType.getPermittedExtensions());
 
         ConcurrentLinkedQueue<String> clangDump = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<String> syntaxErrors = new ConcurrentLinkedQueue<>();
+
+        boolean syntaxOnly = get(SYNTAX_ONLY);
 
         DataStore options = ClangAstKeys.toDataStore(compilerOptions);
 
@@ -117,7 +124,8 @@ public class ParallelCodeParser extends CodeParser {
         ClavaLog.info("Found " + sources.size() + " source files");
         // ClavaLog.debug(() -> "[ParallelCodeParser] Files to parse:" + sources);
 
-        File parsingFolder = SpecsIo.getTempFolder("clava_parsing_" + UUID.randomUUID().toString());
+        File parsingFolder = SpecsIo
+                .getTempFolder((syntaxOnly ? "clava_syntax_validation" : "clava_parsing") + "_" + UUID.randomUUID());
         ClavaLog.debug(() -> "Parsing using folder '" + parsingFolder + "'");
 
         // AtomicInteger currentSourceFileIndex = new AtomicInteger(0);
@@ -139,8 +147,7 @@ public class ParallelCodeParser extends CodeParser {
 
             Future<ClangAstData> tUnit = executor
                     .submit(() -> parseSource(source, id, standard, options, clangDump,
-                            counter, parsingFolder, clangFiles.clangExecutable(), clangFiles.builtinIncludes(),
-                            clangFiles.systemResourceDir()));
+                            counter, parsingFolder, clangFiles, syntaxErrors));
 
             futureTUnits.add(tUnit);
 
@@ -159,6 +166,10 @@ public class ParallelCodeParser extends CodeParser {
                 var parserData = SpecsSystem.get(future);
                 clangParserResults.add(parserData);
             } catch (Exception e) {
+                if (syntaxOnly) {
+                    throw new RuntimeException("Error while validating syntax of file '" + sources.get(i) + "'", e);
+                }
+
                 SpecsLogs.warn("Could not parse file '" + sources.get(i) + "', will be ignored", e);
                 ignoredFiles.add(sources.get(i));
                 continue;
@@ -176,6 +187,16 @@ public class ParallelCodeParser extends CodeParser {
 
         // Delete temporary folder
         SpecsIo.deleteFolder(parsingFolder);
+
+        // No AST was decoded, just report syntax validation errors
+        if (syntaxOnly) {
+            List<String> validationErrors = new ArrayList<>(syntaxErrors);
+            if (!validationErrors.isEmpty() && !get(CONTINUE_ON_PARSING_ERRORS)) {
+                throw new ClavaParserException(validationErrors, clangFiles);
+            }
+
+            return null;
+        }
 
         // List<TranslationUnit> tUnits = SpecsCollections.getStream(allSources.keySet(), get(PARALLEL_PARSING))
         // .map(sourceFile -> parseSource(new File(sourceFile), standard, options, clangDump,
@@ -293,63 +314,6 @@ public class ParallelCodeParser extends CodeParser {
 
     }
 
-    @Override
-    public void validateSyntax(List<File> inputSources, List<String> compilerOptions, ClavaContext context) {
-        DataStore options = ClangAstKeys.toDataStore(compilerOptions);
-        options.add(ClavaNode.CONTEXT, context);
-
-        List<File> sources = SpecsIo.getFileMap(inputSources, SourceType.getPermittedExtensions()).keySet().stream()
-                .map(File::new)
-                .sorted()
-                .collect(Collectors.toList());
-
-        Standard standard = getStandard(sources, options);
-        ClangResources clangResources = new ClangResources(this);
-        var clangFiles = clangResources.getClangFiles(get(ClangAstKeys.LIBC_CXX_MODE));
-        File validationFolder = SpecsIo.getTempFolder("clava_syntax_validation_" + UUID.randomUUID());
-        List<String> errors = new ArrayList<>();
-
-        try {
-            int numThreads = get(PARALLEL_PARSING) ? get(PARSING_NUM_THREADS) : 1;
-            if (numThreads <= 0) {
-                numThreads = Runtime.getRuntime().availableProcessors();
-            }
-
-            ExecutorService executor = Executors.newFixedThreadPool(numThreads);
-            List<Future<String>> validationResults = new ArrayList<>();
-            for (int i = 0; i < sources.size(); i++) {
-                File source = sources.get(i);
-                String id = Integer.toString(i + 1);
-                validationResults.add(executor.submit(() -> validateSource(source, id, standard, options,
-                        validationFolder, clangFiles.clangExecutable(), clangFiles.builtinIncludes(),
-                        clangFiles.systemResourceDir())));
-            }
-            executor.shutdown();
-
-            for (var validationResult : validationResults) {
-                String error = SpecsSystem.get(validationResult);
-                if (error != null) {
-                    errors.add(error);
-                }
-            }
-        } finally {
-            SpecsIo.deleteFolder(validationFolder);
-        }
-
-        if (!errors.isEmpty() && !get(CONTINUE_ON_PARSING_ERRORS)) {
-            throw new ClavaParserException(errors, clangFiles);
-        }
-    }
-
-    private String validateSource(File source, String id, Standard standard, DataStore options, File validationFolder,
-                                  File clangExecutable, List<String> builtinIncludes, File systemResourceDir) {
-
-        var dumper = new ClangAstDumper(false, clangExecutable, builtinIncludes, systemResourceDir, this)
-                .setBaseFolder(validationFolder)
-                .setSystemIncludesThreshold(get(SYSTEM_INCLUDES_THRESHOLD));
-        return dumper.validateSyntax(source, id, standard, options) ? null : dumper.getLastValidationError();
-    }
-
     // private ClangParserData getParserData(Future<ClangParserData> future) {
     // try {
     // return SpecsSystem.get(future);
@@ -416,7 +380,7 @@ public class ParallelCodeParser extends CodeParser {
 
     private ClangAstData parseSource(File sourceFile, String id, Standard standard, DataStore options,
                                      ConcurrentLinkedQueue<String> clangDump, ParallelProgressCounter counter, File parsingFolder,
-                                     File clangExecutable, List<String> builtinIncludes, File systemResourceDir) {
+                                     ClangFiles clangFiles, ConcurrentLinkedQueue<String> syntaxErrors) {
 
         // ConcurrentLinkedQueue<String> clangDump, ConcurrentLinkedQueue<File> workingFolders) {
 
@@ -427,15 +391,25 @@ public class ParallelCodeParser extends CodeParser {
         // Only show output of console after parsing is done, when using parallel parsing
         boolean streamConsoleOutput = !get(PARALLEL_PARSING);
 
-        ClangAstDumper clangParser = new ClangAstDumper(streamConsoleOutput, clangExecutable, builtinIncludes,
-                systemResourceDir, this)
+        ClangAstDumper clangParser = new ClangAstDumper(streamConsoleOutput, clangFiles.clangExecutable(),
+                clangFiles.builtinIncludes(), clangFiles.systemResourceDir(), this)
                 .setBaseFolder(parsingFolder)
                 .setSystemIncludesThreshold(get(SYSTEM_INCLUDES_THRESHOLD));
 
         // .setUsePlatformLibc(get(ClangAstKeys.USE_PLATFORM_INCLUDES));
 
         counter.print(sourceFile);
-        // ClavaLog.info("Parsing '" + sourceFile.getAbsolutePath() + "'");
+
+        // Run the same clang invocation, discard dumper output
+        if (get(SYNTAX_ONLY)) {
+            String error = clangParser.validateSyntax(sourceFile, id, standard, options);
+            if (error != null) {
+                syntaxErrors.add(error);
+            }
+
+            return null;
+        }
+
         ClangAstData clangParserData = clangParser.parse(sourceFile, id, standard, options);
 
         if (get(SHOW_CLANG_DUMP)) {

--- a/ClangAstParser/src/pt/up/fe/specs/clang/codeparser/ParallelCodeParser.java
+++ b/ClangAstParser/src/pt/up/fe/specs/clang/codeparser/ParallelCodeParser.java
@@ -293,6 +293,62 @@ public class ParallelCodeParser extends CodeParser {
 
     }
 
+    @Override
+    public void validateSyntax(List<File> inputSources, List<String> compilerOptions, ClavaContext context) {
+        DataStore options = ClangAstKeys.toDataStore(compilerOptions);
+        options.add(ClavaNode.CONTEXT, context);
+
+        List<File> sources = SpecsIo.getFileMap(inputSources, SourceType.getPermittedExtensions()).keySet().stream()
+                .map(File::new)
+                .sorted()
+                .collect(Collectors.toList());
+
+        Standard standard = getStandard(sources, options);
+        ClangResources clangResources = new ClangResources(this);
+        var clangFiles = clangResources.getClangFiles(get(ClangAstKeys.LIBC_CXX_MODE));
+        File validationFolder = SpecsIo.getTempFolder("clava_syntax_validation_" + UUID.randomUUID());
+        List<String> errors = new ArrayList<>();
+
+        try {
+            int numThreads = get(PARALLEL_PARSING) ? get(PARSING_NUM_THREADS) : 1;
+            if (numThreads <= 0) {
+                numThreads = Runtime.getRuntime().availableProcessors();
+            }
+
+            ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+            List<Future<String>> validationResults = new ArrayList<>();
+            for (int i = 0; i < sources.size(); i++) {
+                File source = sources.get(i);
+                String id = Integer.toString(i + 1);
+                validationResults.add(executor.submit(() -> validateSource(source, id, standard, options,
+                        validationFolder, clangFiles.clangExecutable(), clangFiles.builtinIncludes())));
+            }
+            executor.shutdown();
+
+            for (var validationResult : validationResults) {
+                String error = SpecsSystem.get(validationResult);
+                if (error != null) {
+                    errors.add(error);
+                }
+            }
+        } finally {
+            SpecsIo.deleteFolder(validationFolder);
+        }
+
+        if (!errors.isEmpty() && !get(CONTINUE_ON_PARSING_ERRORS)) {
+            throw new ClavaParserException(errors, clangFiles);
+        }
+    }
+
+    private String validateSource(File source, String id, Standard standard, DataStore options, File validationFolder,
+                                  File clangExecutable, List<String> builtinIncludes) {
+
+        var dumper = new ClangAstDumper(false, clangExecutable, builtinIncludes, this)
+                .setBaseFolder(validationFolder)
+                .setSystemIncludesThreshold(get(SYSTEM_INCLUDES_THRESHOLD));
+        return dumper.validateSyntax(source, id, standard, options) ? null : dumper.getLastValidationError();
+    }
+
     // private ClangParserData getParserData(Future<ClangParserData> future) {
     // try {
     // return SpecsSystem.get(future);

--- a/ClangAstParser/src/pt/up/fe/specs/clang/codeparser/ParallelCodeParser.java
+++ b/ClangAstParser/src/pt/up/fe/specs/clang/codeparser/ParallelCodeParser.java
@@ -124,8 +124,7 @@ public class ParallelCodeParser extends CodeParser {
         ClavaLog.info("Found " + sources.size() + " source files");
         // ClavaLog.debug(() -> "[ParallelCodeParser] Files to parse:" + sources);
 
-        File parsingFolder = SpecsIo
-                .getTempFolder((syntaxOnly ? "clava_syntax_validation" : "clava_parsing") + "_" + UUID.randomUUID());
+        File parsingFolder = SpecsIo.getTempFolder("clava_parsing_" + UUID.randomUUID().toString());
         ClavaLog.debug(() -> "Parsing using folder '" + parsingFolder + "'");
 
         // AtomicInteger currentSourceFileIndex = new AtomicInteger(0);

--- a/ClangAstParser/src/pt/up/fe/specs/clang/codeparser/ParallelCodeParser.java
+++ b/ClangAstParser/src/pt/up/fe/specs/clang/codeparser/ParallelCodeParser.java
@@ -321,7 +321,8 @@ public class ParallelCodeParser extends CodeParser {
                 File source = sources.get(i);
                 String id = Integer.toString(i + 1);
                 validationResults.add(executor.submit(() -> validateSource(source, id, standard, options,
-                        validationFolder, clangFiles.clangExecutable(), clangFiles.builtinIncludes())));
+                        validationFolder, clangFiles.clangExecutable(), clangFiles.builtinIncludes(),
+                        clangFiles.systemResourceDir())));
             }
             executor.shutdown();
 
@@ -341,9 +342,9 @@ public class ParallelCodeParser extends CodeParser {
     }
 
     private String validateSource(File source, String id, Standard standard, DataStore options, File validationFolder,
-                                  File clangExecutable, List<String> builtinIncludes) {
+                                  File clangExecutable, List<String> builtinIncludes, File systemResourceDir) {
 
-        var dumper = new ClangAstDumper(false, clangExecutable, builtinIncludes, this)
+        var dumper = new ClangAstDumper(false, clangExecutable, builtinIncludes, systemResourceDir, this)
                 .setBaseFolder(validationFolder)
                 .setSystemIncludesThreshold(get(SYSTEM_INCLUDES_THRESHOLD));
         return dumper.validateSyntax(source, id, standard, options) ? null : dumper.getLastValidationError();

--- a/ClangAstParser/src/pt/up/fe/specs/clang/dumper/ClangAstDumper.java
+++ b/ClangAstParser/src/pt/up/fe/specs/clang/dumper/ClangAstDumper.java
@@ -141,8 +141,10 @@ public class ClangAstDumper {
 
     /**
      * Invokes Clang with the same arguments as parsing, while discarding dumper output.
+     *
+     * @return null if the syntax is valid, otherwise an error message
      */
-    public boolean validateSyntax(File sourceFile, String id, Standard standard, DataStore config) {
+    public String validateSyntax(File sourceFile, String id, Standard standard, DataStore config) {
         if (config.get(ClangAstKeys.USES_CILK)) {
             sourceFile = new CilkParser().prepareCilkFile(sourceFile);
         }
@@ -150,14 +152,10 @@ public class ClangAstDumper {
         validationOnly = true;
         try {
             parsePrivate(sourceFile, id, standard, config);
-            return lastValidationError == null;
+            return lastValidationError;
         } finally {
             validationOnly = false;
         }
-    }
-
-    public String getLastValidationError() {
-        return lastValidationError;
     }
 
     private ClangAstData parsePrivate(File sourceFile, String id, Standard standard, DataStore config) {
@@ -379,8 +377,6 @@ public class ClangAstDumper {
 
     private String validateSyntax(List<String> arguments, File sourceFile, String id) {
         lastWorkingFolder = SpecsIo.mkdir(baseFolder, sourceFile.getName() + "_" + id);
-        SpecsIo.deleteFolderContents(lastWorkingFolder);
-        workingFolders.add(lastWorkingFolder);
 
         var output = SpecsSystem.runProcess(arguments, lastWorkingFolder,
                 this::discardOutput,

--- a/ClangAstParser/src/pt/up/fe/specs/clang/dumper/ClangAstDumper.java
+++ b/ClangAstParser/src/pt/up/fe/specs/clang/dumper/ClangAstDumper.java
@@ -41,7 +41,6 @@ import pt.up.fe.specs.util.utilities.LineStream;
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -80,6 +79,8 @@ public class ClangAstDumper {
     private File systemResourceDir;
     private int systemIncludesThreshold;
     private final ClangResources clangResources;
+    private boolean validationOnly;
+    private String lastValidationError;
 
     private final CodeParser parserConfig;
 
@@ -136,6 +137,27 @@ public class ClangAstDumper {
         }
 
         return parsePrivate(sourceFile, id, standard, config);
+    }
+
+    /**
+     * Invokes Clang with the same arguments as parsing, while discarding dumper output.
+     */
+    public boolean validateSyntax(File sourceFile, String id, Standard standard, DataStore config) {
+        if (config.get(ClangAstKeys.USES_CILK)) {
+            sourceFile = new CilkParser().prepareCilkFile(sourceFile);
+        }
+
+        validationOnly = true;
+        try {
+            parsePrivate(sourceFile, id, standard, config);
+            return lastValidationError == null;
+        } finally {
+            validationOnly = false;
+        }
+    }
+
+    public String getLastValidationError() {
+        return lastValidationError;
     }
 
     private ClangAstData parsePrivate(File sourceFile, String id, Standard standard, DataStore config) {
@@ -277,6 +299,11 @@ public class ClangAstDumper {
 
         ClavaLog.debug(() -> "Calling Clang AST Dumper: " + arguments);
 
+        if (validationOnly) {
+            lastValidationError = validateSyntax(arguments, sourceFile, id);
+            return null;
+        }
+
         ClangAstData parsedData = null;
         ProcessOutput<String, ClangAstData> output = null;
 
@@ -348,6 +375,36 @@ public class ClangAstDumper {
             ClavaLog.debug("Setting --cuda-path to folder '" + cudaFolder.getAbsolutePath() + "'");
             arguments.add("--cuda-path=" + cudaFolder.getAbsolutePath());
         }
+    }
+
+    private String validateSyntax(List<String> arguments, File sourceFile, String id) {
+        lastWorkingFolder = SpecsIo.mkdir(baseFolder, sourceFile.getName() + "_" + id);
+        SpecsIo.deleteFolderContents(lastWorkingFolder);
+        workingFolders.add(lastWorkingFolder);
+
+        var output = SpecsSystem.runProcess(arguments, lastWorkingFolder,
+                this::discardOutput,
+                inputStream -> processOutput(inputStream));
+
+        output.getOutputException().ifPresent(exception -> {
+            throw new RuntimeException("Exception while validating syntax", exception);
+        });
+
+        if (output.isError()) {
+            return "Syntax validation failed for '" + sourceFile.getAbsolutePath() + "':\n" + output.getStdErr();
+        }
+
+        return null;
+    }
+
+    private String discardOutput(InputStream inputStream) {
+        try (LineStream lines = LineStream.newInstance(inputStream, null)) {
+            while (lines.hasNextLine()) {
+                lines.nextLine();
+            }
+        }
+
+        return "";
     }
 
     private String processOutput(InputStream inputStream) {

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxWeaver.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxWeaver.java
@@ -1232,8 +1232,9 @@ public class CxxWeaver extends ACxxWeaver {
 
         currentBases = rebuildBases;
         if (!update) {
-            newCodeParser().validateSyntax(writtenFiles,
-                    addSourceIncludes(writtenFiles, rebuildOptions, extraOptions), context);
+            CodeParser codeParser = newCodeParser();
+            codeParser.set(ParallelCodeParser.SYNTAX_ONLY, true);
+            codeParser.parse(writtenFiles, addSourceIncludes(writtenFiles, rebuildOptions, extraOptions), context);
             currentBases = previousBases;
             return true;
         }

--- a/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxWeaver.java
+++ b/ClavaWeaver/src/pt/up/fe/specs/clava/weaver/CxxWeaver.java
@@ -575,26 +575,26 @@ public class CxxWeaver extends ACxxWeaver {
         ClavaLog.debug(() -> "Creating App using the following options: " + parserOptions);
         ClavaLog.debug(() -> "Creating App using the following extra options: " + extraOptions);
 
-        // Collect additional include folders
-        Set<String> sourceIncludeFolders = getSourceIncludes(sources);
-        ClavaLog.debug(() -> "Source include folders: " + sourceIncludeFolders);
+        CodeParser codeParser = newCodeParser();
 
-        // Add include folders to extra options
-        List<String> adaptedExtraOptions = new ArrayList<>(sourceIncludeFolders.size() + extraOptions.size());
-        adaptedExtraOptions.addAll(extraOptions);
-        sourceIncludeFolders.stream().map(includeFolder -> "-I" + includeFolder).forEach(adaptedExtraOptions::add);
+        List<String> allParserOptions = addSourceIncludes(sources, parserOptions, extraOptions);
+        App app = codeParser.parse(sources, allParserOptions, context);
 
-        List<String> allFiles = sources.stream().map(File::toString).collect(Collectors.toList());
+        // Set source paths of each TranslationUnit
+        app.setSources(currentBases);
+        app.setSourceFoldernames(sourceFoldernames);
 
-        // Sort filenames so that select order of files is consistent between OSes
-        Collections.sort(allFiles);
+        // Set external dependencies
+        app.getExternalDependencies()
+                .setDisableRemoteDependencies(this.dataStore.get(ClavaOptions.DISABLE_REMOTE_DEPENDENCIES));
 
-        boolean useCustomResources = this.dataStore.get(ClavaOptions.CUSTOM_RESOURCES);
+        return app;
+    }
 
+    private CodeParser newCodeParser() {
         CodeParser codeParser = CodeParser.newInstance();
 
-        // Setup code parser
-        codeParser.set(CodeParser.USE_CUSTOM_RESOURCES, useCustomResources);
+        codeParser.set(CodeParser.USE_CUSTOM_RESOURCES, this.dataStore.get(ClavaOptions.CUSTOM_RESOURCES));
         codeParser.set(CodeParser.CUDA_GPU_ARCH, this.dataStore.get(CodeParser.CUDA_GPU_ARCH));
         codeParser.set(CodeParser.CUDA_PATH, this.dataStore.get(CodeParser.CUDA_PATH));
         codeParser.set(ParallelCodeParser.PARALLEL_PARSING, this.dataStore.get(ParallelCodeParser.PARALLEL_PARSING));
@@ -606,20 +606,18 @@ public class CxxWeaver extends ACxxWeaver {
         codeParser.set(ClangAstKeys.LIBC_CXX_MODE, this.dataStore.get(ClangAstKeys.LIBC_CXX_MODE));
         codeParser.set(CodeParser.DUMPER_FOLDER, this.dataStore.get(CodeParser.DUMPER_FOLDER));
 
-        List<String> allParserOptions = new ArrayList<>(parserOptions.size() + adaptedExtraOptions.size());
+        return codeParser;
+    }
+
+    private List<String> addSourceIncludes(List<File> sources, List<String> parserOptions, List<String> extraOptions) {
+        Set<String> sourceIncludeFolders = getSourceIncludes(sources);
+        ClavaLog.debug(() -> "Source include folders: " + sourceIncludeFolders);
+
+        List<String> allParserOptions = new ArrayList<>(parserOptions.size() + sourceIncludeFolders.size() + extraOptions.size());
         allParserOptions.addAll(parserOptions);
-        allParserOptions.addAll(adaptedExtraOptions);
-        App app = codeParser.parse(SpecsCollections.map(allFiles, File::new), allParserOptions, context);
-
-        // Set source paths of each TranslationUnit
-        app.setSources(currentBases);
-        app.setSourceFoldernames(sourceFoldernames);
-
-        // Set external dependencies
-        app.getExternalDependencies()
-                .setDisableRemoteDependencies(this.dataStore.get(ClavaOptions.DISABLE_REMOTE_DEPENDENCIES));
-
-        return app;
+        allParserOptions.addAll(extraOptions);
+        sourceIncludeFolders.stream().map(includeFolder -> "-I" + includeFolder).forEach(allParserOptions::add);
+        return allParserOptions;
     }
 
     private Set<String> getSourceIncludes(List<File> sources) {
@@ -1233,6 +1231,13 @@ public class CxxWeaver extends ACxxWeaver {
                 .forEach(writtenFile -> rebuildBases.put(SpecsIo.getCanonicalFile(writtenFile), tempFolder));
 
         currentBases = rebuildBases;
+        if (!update) {
+            newCodeParser().validateSyntax(writtenFiles,
+                    addSourceIncludes(writtenFiles, rebuildOptions, extraOptions), context);
+            currentBases = previousBases;
+            return true;
+        }
+
         App rebuiltApp = createApp(writtenFiles, rebuildOptions, extraOptions);
 
         // Restore current bases


### PR DESCRIPTION
Clava's `rebuildAst(false)` path validated rewritten source by running clang/clang-dumper and then decoding the complete AST even though the rebuilt tree was immediately discarded.

This adds a diagnostics-only validation path: it invokes the same clang/clang-dumper pipeline, drains stdout without AST decoding, preserves stderr and exit-status handling, and leaves `rebuildAst(true)` on the full-parse path. The validator also receives the system resource directory required by the current clang setup.

Measured impact: six paired runs show a median execution-time reduction of 11.1% (14.02 s); the mean reduction is 13.2%. The paired 95% confidence interval for the saving is 9.42–23.42 s (p = 0.0018). [Full benchmark report](https://draftlink.lmsousa.workers.dev/d/F8R61NdobCYl).

Verification:

- `gradle --project-dir ClavaWeaver clean installDist`
- `git diff --check`
- output-checked Clava-JS suite: 161 passed, 3 skipped (excluding the pre-existing FileIterator failure from unrelated staged Lara changes)

Model: Codex (GPT-5.6-luna).